### PR TITLE
insight AST -> JSON compiler

### DIFF
--- a/packages/curriculum-compiler-json/README.md
+++ b/packages/curriculum-compiler-json/README.md
@@ -13,16 +13,16 @@ The compiler works in the following way:
 
 1. Iterates over all `children` of the AST provided
     - looks at the `type` value of each top-most node
-    - if type is `"yaml"` => fires metadata compiler
-    - if type is `"headline"` => fires headline compiler
+    - if type is `"yaml"` => fires [metadata](#metadata) compiler
+    - if type is `"headline"` => fires [headline](#headline) compiler
     - if type is `"section"`, it looks at the `name` field of the node
       - if name is `"Content"` => returns `{ content: compileString(node) }`
       - if name is `"Game Content"` => returns `{ gameContent: compileString(node) }`
       - if name is `"Exercise"` => returns `{ exercise: compileString(node) }`
-      - if name is `"Practice"` => fires question compiler with "practice" argument
-      - if name is `"Revision"` => fires question compiler with "revision" argument
-      - if name is `"Quiz"` => fires quiz compiler
-      - if name is `"Footnotes"` => fires footnotes compiler
+      - if name is `"Practice"` => fires [question](#question) compiler with "practice" argument
+      - if name is `"Revision"` => fires [question](#question) compiler with "revision" argument
+      - if name is `"Quiz"` => fires [quiz](#quiz) compiler
+      - if name is `"Footnotes"` => fires [footnotes](#footnotes) compiler
       - otherwise throws an error
     - otherwise throws an error
 2. combines all JSON properties returned by each sub-compiler into a single object

--- a/packages/curriculum-compiler-json/README.md
+++ b/packages/curriculum-compiler-json/README.md
@@ -1,0 +1,377 @@
+# Enki Curriculum Compiler JSON
+
+[npm-badge]: https://img.shields.io/npm/v/@enkidevs/curriculum-compiler-json.png?style=flat-square
+[npm]: https://www.npmjs.com/package/@enkidevs/curriculum-compiler-json
+
+Compiles Enki Curriculum AST into a json object.
+
+See [Enki curriculum processors](https://github.com/enkidevs/curriculum-processors)  for more details.
+
+## How it works
+
+The compiler works in the following way:
+
+1. Iterates over all `children` of the AST provided
+    - looks at the `type` value of each top-most node
+    - if type is `"yaml"` => fires metadata compiler
+    - if type is `"headline"` => fires headline compiler
+    - if type is `"section"`, it looks at the `name` field of the node
+      - if name is `"Content"` => returns `{ content: compileString(node) }`
+      - if name is `"Game Content"` => returns `{ gameContent: compileString(node) }`
+      - if name is `"Exercise"` => returns `{ exercise: compileString(node) }`
+      - if name is `"Practice"` => fires question compiler with "practice" argument
+      - if name is `"Revision"` => fires question compiler with "revision" argument
+      - if name is `"Quiz"` => fires quiz compiler
+      - if name is `"Footnotes"` => fires footnotes compiler
+      - otherwise throws an error
+    - otherwise throws an error
+2. combines all JSON properties returned by each sub-compiler into a single object
+3. returns the final JSON object
+
+## Compilers
+
+Most of the compilers make use of the [string compiler](https://github.com/enkidevs/curriculum-processors/tree/master/packages/curriculum-compiler-string) on top of which they do subsequent modifications.
+
+Each of them will return a simple object `{ key: value }`
+
+### Headline
+
+```javascript
+compilers.headline(node)
+```
+
+Given an AST node as input:
+
+```json
+{
+  "type": "headline",
+  "children": [
+    {
+      "type": "text",
+      "value": "Sample title",
+      ///
+      }
+    }
+  }
+```
+
+It will compile the node, remove the `\n`s, trim the string and return an object:
+
+```json
+{
+  "headline": "Sample title"
+}
+```
+
+### Metadata
+
+```javascript
+compilers.metadata(node)
+```
+
+Given an AST node as input:
+
+```json
+{
+  "type": "yaml",
+  "value": "author: catalin\n\nlevels:\n  - basic\n  - medium\n  -...",
+  "data": {
+    "parsedData": {
+      "author": "catalin",
+      ...
+    }
+  }
+```
+
+It will return the already parsed data in `node.data.parsedValue`:
+
+```json
+{
+  "metadata": {
+    "author": "catalin",
+    ...
+  }
+}
+```
+
+### Question
+
+```javascript
+compilers.question(node, 'key')
+```
+
+This compiler is used for both "Practice" and "Revision" questions. Apart from the `ast`, this compiler takes another argument `key`:
+
+```javascript
+question(ast, key) { /* ... */ }
+```
+
+Given a question AST node as input and a `key`:
+
+```json
+{
+  "type": "section",
+  "name": "Revision" || "Practice",
+  "children": [...]
+}
+```
+
+It will return:
+
+```json
+{
+  "key": {
+    "rawText": "question with two gaps ??? ???\n* answer1\n*answer2\nanswer3",
+    "question": "question with two gaps ??? ???",
+    "answers": [
+      {
+        "text": "answer1",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "answer2",
+        "correct": true,
+        "correctIndex": 1
+      },
+      {
+        "text": "answer3",
+        "correct": false,
+        "correctIndex": null
+      }
+    ]
+  }
+}
+```
+
+Each answer will have its `text`, a `correct` flag indicating if it's one of the correct answers of the question and a `correctIndex` integer which indicates the index of the question gap it should match.
+
+### Quiz
+
+```javascript
+compilers.quiz(node)
+```
+
+This compiler is similar to the `question` compiler. In addition, it returns a `headline` field specific to quizzes.
+
+Because quiz question don't have question gaps `???`, the first answer will be marked as `correct` (from within the parser).
+
+Given an AST node:
+
+```json
+{
+  "type": "section",
+  "name": "Quiz",
+  "children": [ ... ]
+}
+```
+
+It returns the following object:
+
+```json
+{
+  "quiz": {
+    "rawText": "### Quiz name\nQuiz text\n* answer1\nanswer2",
+    "headline": "Quiz name",
+    "question": "Quiz text",
+    "answers": [
+       {
+        "text": "answer1",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "answer2",
+        "correct": false,
+        "correctIndex": null
+      }
+    ]
+  }
+}
+```
+
+### Footnotes
+
+```javascript
+compilers.footnotes(node)
+```
+
+Given an AST node:
+
+```json
+{
+  "type": "section",
+  "name": "Footnotes",
+  "children": [ ... ]
+}
+```
+
+It returns the following object:
+
+```json
+{
+  "footnotes": {
+    "rawText": "fullFootnotesText",
+    "items": [
+      {
+        "number": 1,
+        "name": "Footnote name",
+        "text": "Footnote text"
+      },
+       {
+        "number": 2,
+        "name": "Footnote name 2",
+        "text": "Footnote text 2"
+      }
+    ]
+  }
+}
+```
+
+## Schema
+
+The final schema of a compiled JSON looks like:
+
+```json
+{
+  "metadata": {
+    "author": "catalin",
+    "levels": [
+      "basic",
+      "medium",
+      "advanced"
+    ],
+    "type": "normal",
+    "category": "must-know",
+    "standards": {
+      "sql.use-dql.0": 10,
+      "sql.use-ddl.1": 1000
+    },
+    "tags": [
+      "introduction",
+      "workout"
+    ],
+    "stub": false,
+    "links": [
+      {
+        "name": "EnkiCool",
+        "url": "https://enki.com",
+        "nature": "website"
+      }
+    ]
+  },
+  "headline": "Sample title with `code` within",
+  "content": "This is a sample paragraph.[1]\n\nThis is a sample list[2]&#x3A;\n\n* item one\n* item `two`\n\nSample code[3]&#x3A;\n\n```javascript\nconsole.log('sample code')\n```\n",
+  "gameContent": "Sample game content\n",
+  "exercise": "Sample exercise\n",
+  "practice": {
+    "rawText": "This is a sample question with one gap:\n\n???\n\n* correct\n* incorrect\n* not a chance\n",
+    "question": "This is a sample question with one gap:\n\n???\n",
+    "answers": [
+      {
+        "text": "correct",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "incorrect",
+        "correct": true,
+        "correctIndex": 1
+      },
+      {
+        "text": "not a chance",
+        "correct": true,
+        "correctIndex": 2
+      }
+    ]
+  },
+  "revision": {
+    "rawText": "This is a sample question with two gaps:\n\n???\n\n???\n\n* correct\n* also correct\n* nah bro\n* fam, just no\n",
+    "question": "This is a sample question with two gaps:\n\n???\n\n???\n",
+    "answers": [
+      {
+        "text": "correct",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "also correct",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "nah bro",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "fam, just no",
+        "correct": false,
+        "correctIndex": null
+      }
+    ]
+  },
+  "quiz": {
+    "rawText": "### Quiz title\n\n\nSample quiz question\n\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
+    "headline": "Quiz title",
+    "question": "Sample quiz question\n",
+    "answers": [
+      {
+        "text": "correct",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "*incorrect*",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "not a `chance`",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "nope",
+        "correct": false,
+        "correctIndex": null
+      }
+    ]
+  },
+  "footnotes": {
+    "rawText": "[1: Paragraph]\nSample explanation\n\n[2: List]\nSample list\n\n[3: Code]\nSample code\n\n```javascript\nvar x = 10\n```\n",
+    "items": [
+      {
+        "number": "1",
+        "name": " Paragraph",
+        "text": "\nSample explanation\n\n"
+      },
+      {
+        "number": "2",
+        "name": " List",
+        "text": "\nSample list\n\n"
+      },
+      {
+        "number": "3",
+        "name": " Code",
+        "text": "\nSample code\n\n```javascript\nvar x = 10\n```\n"
+      }
+    ]
+  }
+}
+```
+
+## API
+
+Use the package like:
+
+```js
+const {
+  contentTypes
+} = require('@enkidevs/curriculum-helpers')
+const {
+  getCompiler
+} = require('@enkidevs/curriculum-compiler-json')
+
+const json = getCompiler(contentTypes.INSIGHT).compileSync(ast)
+```

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/ast.json
@@ -1,0 +1,562 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "yaml",
+      "value": "author: SebaRaba\n\nlevels:\n  - beginner\n  - basic\n  - medium\n\ntags:\n  - introduction\n  - workout\n\ntype: exercise\n\nlinkType: sqlfiddle\n\nlink: http://sqlfiddle.com/#!9/d5ccaa\n\nstandards:\n  sql.define-columns.1: 1000\n  sql.define-columns.2: 1000\n\nlinks:\n  - '[mysql modify columns documentation](https://dev.mysql.com/doc/refman/5.7/en/alter-table.html){website}'\n  - '[blog post on mysql define tables](https://www.w3schools.com/sql/sql_alter.asp){website}'\n  - '[video tutorial on alter table](https://youtu.be/vDr2DZeU5mY?t=50s){video}'\n",
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 28,
+          "column": 4,
+          "offset": 544
+        },
+        "indent": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "data": {
+        "parsedValue": {
+          "author": "SebaRaba",
+          "levels": [
+            "beginner",
+            "basic",
+            "medium"
+          ],
+          "tags": [
+            "introduction",
+            "workout"
+          ],
+          "type": "exercise",
+          "linkType": "sqlfiddle",
+          "link": "http://sqlfiddle.com/#!9/d5ccaa",
+          "standards": {
+            "sql.define-columns.1": 1000,
+            "sql.define-columns.2": 1000
+          },
+          "links": [
+            {
+              "name": "mysql modify columns documentation",
+              "url": "https://dev.mysql.com/doc/refman/5.7/en/alter-table.html",
+              "nature": "website"
+            },
+            {
+              "name": "blog post on mysql define tables",
+              "url": "https://www.w3schools.com/sql/sql_alter.asp",
+              "nature": "website"
+            },
+            {
+              "name": "video tutorial on alter table",
+              "url": "https://youtu.be/vDr2DZeU5mY?t=50s",
+              "nature": "video"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "headline",
+      "children": [
+        {
+          "type": "text",
+          "value": "SQL Practice Aggregate Average",
+          "position": {
+            "start": {
+              "line": 29,
+              "column": 3,
+              "offset": 547
+            },
+            "end": {
+              "line": 29,
+              "column": 33,
+              "offset": 577
+            },
+            "indent": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "name": "Exercise",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Follow the link to SQLFiddle and examine the ",
+              "position": {
+                "start": {
+                  "line": 34,
+                  "column": 1,
+                  "offset": 604
+                },
+                "end": {
+                  "line": 34,
+                  "column": 46,
+                  "offset": 649
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "inlineCode",
+              "value": "CREATE",
+              "position": {
+                "start": {
+                  "line": 34,
+                  "column": 46,
+                  "offset": 649
+                },
+                "end": {
+                  "line": 34,
+                  "column": 54,
+                  "offset": 657
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " statements in the lefthand window.",
+              "position": {
+                "start": {
+                  "line": 34,
+                  "column": 54,
+                  "offset": 657
+                },
+                "end": {
+                  "line": 34,
+                  "column": 89,
+                  "offset": 692
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 34,
+              "column": 1,
+              "offset": 604
+            },
+            "end": {
+              "line": 34,
+              "column": 89,
+              "offset": 692
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Consider the ",
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 1,
+                  "offset": 694
+                },
+                "end": {
+                  "line": 36,
+                  "column": 14,
+                  "offset": 707
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "inlineCode",
+              "value": "item_pictures",
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 14,
+                  "offset": 707
+                },
+                "end": {
+                  "line": 36,
+                  "column": 29,
+                  "offset": 722
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " table. It turns out the maxiumum length of the ",
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 29,
+                  "offset": 722
+                },
+                "end": {
+                  "line": 36,
+                  "column": 77,
+                  "offset": 770
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "inlineCode",
+              "value": "URL",
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 77,
+                  "offset": 770
+                },
+                "end": {
+                  "line": 36,
+                  "column": 82,
+                  "offset": 775
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " field is much too short to hold mosts urls.",
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 82,
+                  "offset": 775
+                },
+                "end": {
+                  "line": 36,
+                  "column": 126,
+                  "offset": 819
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 36,
+              "column": 1,
+              "offset": 694
+            },
+            "end": {
+              "line": 36,
+              "column": 126,
+              "offset": 819
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Unfortunately, the schema is already in production, so re-creating the database is not an option.",
+              "position": {
+                "start": {
+                  "line": 38,
+                  "column": 1,
+                  "offset": 821
+                },
+                "end": {
+                  "line": 38,
+                  "column": 98,
+                  "offset": 918
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 38,
+              "column": 1,
+              "offset": 821
+            },
+            "end": {
+              "line": 38,
+              "column": 98,
+              "offset": 918
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Write a statement to modify the ",
+              "position": {
+                "start": {
+                  "line": 40,
+                  "column": 1,
+                  "offset": 920
+                },
+                "end": {
+                  "line": 40,
+                  "column": 33,
+                  "offset": 952
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "inlineCode",
+              "value": "item_pictures",
+              "position": {
+                "start": {
+                  "line": 40,
+                  "column": 33,
+                  "offset": 952
+                },
+                "end": {
+                  "line": 40,
+                  "column": 48,
+                  "offset": 967
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " table to adapt to the problem presented.",
+              "position": {
+                "start": {
+                  "line": 40,
+                  "column": 48,
+                  "offset": 967
+                },
+                "end": {
+                  "line": 40,
+                  "column": 89,
+                  "offset": 1008
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "break",
+              "position": {
+                "start": {
+                  "line": 40,
+                  "column": 89,
+                  "offset": 1008
+                },
+                "end": {
+                  "line": 41,
+                  "column": 1,
+                  "offset": 1011
+                },
+                "indent": [
+                  1
+                ]
+              }
+            },
+            {
+              "type": "text",
+              "value": "Don't directly edit the ",
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 1,
+                  "offset": 1011
+                },
+                "end": {
+                  "line": 41,
+                  "column": 25,
+                  "offset": 1035
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "inlineCode",
+              "value": "CREATE",
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 25,
+                  "offset": 1035
+                },
+                "end": {
+                  "line": 41,
+                  "column": 33,
+                  "offset": 1043
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " statements; instead, write a new statement to alter (",
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 33,
+                  "offset": 1043
+                },
+                "end": {
+                  "line": 41,
+                  "column": 87,
+                  "offset": 1097
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "emphasis",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "hint",
+                  "position": {
+                    "start": {
+                      "line": 41,
+                      "column": 88,
+                      "offset": 1098
+                    },
+                    "end": {
+                      "line": 41,
+                      "column": 92,
+                      "offset": 1102
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 87,
+                  "offset": 1097
+                },
+                "end": {
+                  "line": 41,
+                  "column": 93,
+                  "offset": 1103
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": ") the table.",
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 93,
+                  "offset": 1103
+                },
+                "end": {
+                  "line": 41,
+                  "column": 105,
+                  "offset": 1115
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 40,
+              "column": 1,
+              "offset": 920
+            },
+            "end": {
+              "line": 41,
+              "column": 105,
+              "offset": 1115
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "To submit, run your SQL and then add the link from SQLFiddle to your submission.  ",
+              "position": {
+                "start": {
+                  "line": 43,
+                  "column": 1,
+                  "offset": 1119
+                },
+                "end": {
+                  "line": 43,
+                  "column": 83,
+                  "offset": 1201
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 43,
+              "column": 1,
+              "offset": 1119
+            },
+            "end": {
+              "line": 43,
+              "column": 83,
+              "offset": 1201
+            },
+            "indent": []
+          }
+        }
+      ]
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 44,
+      "column": 1,
+      "offset": 1202
+    }
+  }
+}

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/ast.json
@@ -3,7 +3,7 @@
   "children": [
     {
       "type": "yaml",
-      "value": "author: SebaRaba\n\nlevels:\n  - beginner\n  - basic\n  - medium\n\ntags:\n  - introduction\n  - workout\n\ntype: exercise\n\nlinkType: sqlfiddle\n\nlink: http://sqlfiddle.com/#!9/d5ccaa\n\nstandards:\n  sql.define-columns.1: 1000\n  sql.define-columns.2: 1000\n\nlinks:\n  - '[mysql modify columns documentation](https://dev.mysql.com/doc/refman/5.7/en/alter-table.html){website}'\n  - '[blog post on mysql define tables](https://www.w3schools.com/sql/sql_alter.asp){website}'\n  - '[video tutorial on alter table](https://youtu.be/vDr2DZeU5mY?t=50s){video}'\n",
+      "value": "author: catalin\n\nlevels:\n  - beginner\n\ntags:\n  - introduction\n\ntype: exercise\n\nlinkType: sqlfiddle\n\nlink: http://sqlfiddle.com/#!9/352b0f1/1\n\nanswer: /heal-ball/\n\nstandards:\n  sql.read-single-table.0: 1000\n\nlinks:\n  - '[Enki](https:/enki.com){website}'\n",
       "position": {
         "start": {
           "line": 1,
@@ -11,15 +11,11 @@
           "offset": 0
         },
         "end": {
-          "line": 28,
+          "line": 24,
           "column": 4,
-          "offset": 544
+          "offset": 261
         },
         "indent": [
-          1,
-          1,
-          1,
-          1,
           1,
           1,
           1,
@@ -47,38 +43,25 @@
       },
       "data": {
         "parsedValue": {
-          "author": "SebaRaba",
+          "author": "catalin",
           "levels": [
-            "beginner",
-            "basic",
-            "medium"
+            "beginner"
           ],
           "tags": [
-            "introduction",
-            "workout"
+            "introduction"
           ],
           "type": "exercise",
           "linkType": "sqlfiddle",
-          "link": "http://sqlfiddle.com/#!9/d5ccaa",
+          "link": "http://sqlfiddle.com/#!9/352b0f1/1",
+          "answer": "/heal-ball/",
           "standards": {
-            "sql.define-columns.1": 1000,
-            "sql.define-columns.2": 1000
+            "sql.read-single-table.0": 1000
           },
           "links": [
             {
-              "name": "mysql modify columns documentation",
-              "url": "https://dev.mysql.com/doc/refman/5.7/en/alter-table.html",
+              "name": "Enki",
+              "url": "https:/enki.com",
               "nature": "website"
-            },
-            {
-              "name": "blog post on mysql define tables",
-              "url": "https://www.w3schools.com/sql/sql_alter.asp",
-              "nature": "website"
-            },
-            {
-              "name": "video tutorial on alter table",
-              "url": "https://youtu.be/vDr2DZeU5mY?t=50s",
-              "nature": "video"
             }
           ]
         }
@@ -89,17 +72,17 @@
       "children": [
         {
           "type": "text",
-          "value": "SQL Practice Aggregate Average",
+          "value": "Sample exercise",
           "position": {
             "start": {
-              "line": 29,
+              "line": 25,
               "column": 3,
-              "offset": 547
+              "offset": 264
             },
             "end": {
-              "line": 29,
-              "column": 33,
-              "offset": 577
+              "line": 25,
+              "column": 18,
+              "offset": 279
             },
             "indent": []
           }
@@ -115,51 +98,51 @@
           "children": [
             {
               "type": "text",
-              "value": "Follow the link to SQLFiddle and examine the ",
+              "value": "Sample exercise ",
               "position": {
                 "start": {
-                  "line": 34,
+                  "line": 30,
                   "column": 1,
-                  "offset": 604
+                  "offset": 306
                 },
                 "end": {
-                  "line": 34,
-                  "column": 46,
-                  "offset": 649
+                  "line": 30,
+                  "column": 17,
+                  "offset": 322
                 },
                 "indent": []
               }
             },
             {
               "type": "inlineCode",
-              "value": "CREATE",
+              "value": "body",
               "position": {
                 "start": {
-                  "line": 34,
-                  "column": 46,
-                  "offset": 649
+                  "line": 30,
+                  "column": 17,
+                  "offset": 322
                 },
                 "end": {
-                  "line": 34,
-                  "column": 54,
-                  "offset": 657
+                  "line": 30,
+                  "column": 23,
+                  "offset": 328
                 },
                 "indent": []
               }
             },
             {
               "type": "text",
-              "value": " statements in the lefthand window.",
+              "value": ":",
               "position": {
                 "start": {
-                  "line": 34,
-                  "column": 54,
-                  "offset": 657
+                  "line": 30,
+                  "column": 23,
+                  "offset": 328
                 },
                 "end": {
-                  "line": 34,
-                  "column": 89,
-                  "offset": 692
+                  "line": 30,
+                  "column": 24,
+                  "offset": 329
                 },
                 "indent": []
               }
@@ -167,14 +150,14 @@
           ],
           "position": {
             "start": {
-              "line": 34,
+              "line": 30,
               "column": 1,
-              "offset": 604
+              "offset": 306
             },
             "end": {
-              "line": 34,
-              "column": 89,
-              "offset": 692
+              "line": 30,
+              "column": 24,
+              "offset": 329
             },
             "indent": []
           }
@@ -184,85 +167,17 @@
           "children": [
             {
               "type": "text",
-              "value": "Consider the ",
+              "value": "Code:",
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 32,
                   "column": 1,
-                  "offset": 694
+                  "offset": 331
                 },
                 "end": {
-                  "line": 36,
-                  "column": 14,
-                  "offset": 707
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "inlineCode",
-              "value": "item_pictures",
-              "position": {
-                "start": {
-                  "line": 36,
-                  "column": 14,
-                  "offset": 707
-                },
-                "end": {
-                  "line": 36,
-                  "column": 29,
-                  "offset": 722
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " table. It turns out the maxiumum length of the ",
-              "position": {
-                "start": {
-                  "line": 36,
-                  "column": 29,
-                  "offset": 722
-                },
-                "end": {
-                  "line": 36,
-                  "column": 77,
-                  "offset": 770
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "inlineCode",
-              "value": "URL",
-              "position": {
-                "start": {
-                  "line": 36,
-                  "column": 77,
-                  "offset": 770
-                },
-                "end": {
-                  "line": 36,
-                  "column": 82,
-                  "offset": 775
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " field is much too short to hold mosts urls.",
-              "position": {
-                "start": {
-                  "line": 36,
-                  "column": 82,
-                  "offset": 775
-                },
-                "end": {
-                  "line": 36,
-                  "column": 126,
-                  "offset": 819
+                  "line": 32,
+                  "column": 6,
+                  "offset": 336
                 },
                 "indent": []
               }
@@ -270,278 +185,37 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 32,
               "column": 1,
-              "offset": 694
+              "offset": 331
             },
             "end": {
-              "line": 36,
-              "column": 126,
-              "offset": 819
+              "line": 32,
+              "column": 6,
+              "offset": 336
             },
             "indent": []
           }
         },
         {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Unfortunately, the schema is already in production, so re-creating the database is not an option.",
-              "position": {
-                "start": {
-                  "line": 38,
-                  "column": 1,
-                  "offset": 821
-                },
-                "end": {
-                  "line": 38,
-                  "column": 98,
-                  "offset": 918
-                },
-                "indent": []
-              }
-            }
-          ],
+          "type": "code",
+          "lang": null,
+          "value": "var x = 10",
           "position": {
             "start": {
-              "line": 38,
+              "line": 33,
               "column": 1,
-              "offset": 821
+              "offset": 337
             },
             "end": {
-              "line": 38,
-              "column": 98,
-              "offset": 918
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Write a statement to modify the ",
-              "position": {
-                "start": {
-                  "line": 40,
-                  "column": 1,
-                  "offset": 920
-                },
-                "end": {
-                  "line": 40,
-                  "column": 33,
-                  "offset": 952
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "inlineCode",
-              "value": "item_pictures",
-              "position": {
-                "start": {
-                  "line": 40,
-                  "column": 33,
-                  "offset": 952
-                },
-                "end": {
-                  "line": 40,
-                  "column": 48,
-                  "offset": 967
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " table to adapt to the problem presented.",
-              "position": {
-                "start": {
-                  "line": 40,
-                  "column": 48,
-                  "offset": 967
-                },
-                "end": {
-                  "line": 40,
-                  "column": 89,
-                  "offset": 1008
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "break",
-              "position": {
-                "start": {
-                  "line": 40,
-                  "column": 89,
-                  "offset": 1008
-                },
-                "end": {
-                  "line": 41,
-                  "column": 1,
-                  "offset": 1011
-                },
-                "indent": [
-                  1
-                ]
-              }
-            },
-            {
-              "type": "text",
-              "value": "Don't directly edit the ",
-              "position": {
-                "start": {
-                  "line": 41,
-                  "column": 1,
-                  "offset": 1011
-                },
-                "end": {
-                  "line": 41,
-                  "column": 25,
-                  "offset": 1035
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "inlineCode",
-              "value": "CREATE",
-              "position": {
-                "start": {
-                  "line": 41,
-                  "column": 25,
-                  "offset": 1035
-                },
-                "end": {
-                  "line": 41,
-                  "column": 33,
-                  "offset": 1043
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " statements; instead, write a new statement to alter (",
-              "position": {
-                "start": {
-                  "line": 41,
-                  "column": 33,
-                  "offset": 1043
-                },
-                "end": {
-                  "line": 41,
-                  "column": 87,
-                  "offset": 1097
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "emphasis",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "hint",
-                  "position": {
-                    "start": {
-                      "line": 41,
-                      "column": 88,
-                      "offset": 1098
-                    },
-                    "end": {
-                      "line": 41,
-                      "column": 92,
-                      "offset": 1102
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 41,
-                  "column": 87,
-                  "offset": 1097
-                },
-                "end": {
-                  "line": 41,
-                  "column": 93,
-                  "offset": 1103
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": ") the table.",
-              "position": {
-                "start": {
-                  "line": 41,
-                  "column": 93,
-                  "offset": 1103
-                },
-                "end": {
-                  "line": 41,
-                  "column": 105,
-                  "offset": 1115
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 40,
-              "column": 1,
-              "offset": 920
-            },
-            "end": {
-              "line": 41,
-              "column": 105,
-              "offset": 1115
+              "line": 35,
+              "column": 4,
+              "offset": 355
             },
             "indent": [
+              1,
               1
             ]
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "To submit, run your SQL and then add the link from SQLFiddle to your submission.  ",
-              "position": {
-                "start": {
-                  "line": 43,
-                  "column": 1,
-                  "offset": 1119
-                },
-                "end": {
-                  "line": 43,
-                  "column": 83,
-                  "offset": 1201
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 43,
-              "column": 1,
-              "offset": 1119
-            },
-            "end": {
-              "line": 43,
-              "column": 83,
-              "offset": 1201
-            },
-            "indent": []
           }
         }
       ]
@@ -554,9 +228,9 @@
       "offset": 0
     },
     "end": {
-      "line": 44,
+      "line": 36,
       "column": 1,
-      "offset": 1202
+      "offset": 356
     }
   }
 }

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/parsed.json
@@ -1,40 +1,27 @@
 {
   "metadata": {
-    "author": "SebaRaba",
+    "author": "catalin",
     "levels": [
-      "beginner",
-      "basic",
-      "medium"
+      "beginner"
     ],
     "tags": [
-      "introduction",
-      "workout"
+      "introduction"
     ],
     "type": "exercise",
     "linkType": "sqlfiddle",
-    "link": "http://sqlfiddle.com/#!9/d5ccaa",
+    "link": "http://sqlfiddle.com/#!9/352b0f1/1",
+    "answer": "/heal-ball/",
     "standards": {
-      "sql.define-columns.1": 1000,
-      "sql.define-columns.2": 1000
+      "sql.read-single-table.0": 1000
     },
     "links": [
       {
-        "name": "mysql modify columns documentation",
-        "url": "https://dev.mysql.com/doc/refman/5.7/en/alter-table.html",
+        "name": "Enki",
+        "url": "https:/enki.com",
         "nature": "website"
-      },
-      {
-        "name": "blog post on mysql define tables",
-        "url": "https://www.w3schools.com/sql/sql_alter.asp",
-        "nature": "website"
-      },
-      {
-        "name": "video tutorial on alter table",
-        "url": "https://youtu.be/vDr2DZeU5mY?t=50s",
-        "nature": "video"
       }
     ]
   },
-  "headline": "SQL Practice Aggregate Average",
-  "exercise": "Follow the link to SQLFiddle and examine the `CREATE` statements in the lefthand window.\n\nConsider the `item_pictures` table. It turns out the maxiumum length of the `URL` field is much too short to hold mosts urls.\n\nUnfortunately, the schema is already in production, so re-creating the database is not an option.\n\nWrite a statement to modify the `item_pictures` table to adapt to the problem presented.  \nDon't directly edit the `CREATE` statements; instead, write a new statement to alter (*hint*) the table.\n\nTo submit, run your SQL and then add the link from SQLFiddle to your submission.  \n"
+  "headline": "Sample exercise",
+  "exercise": "Sample exercise `body`:\n\nCode:\n\n    var x = 10\n"
 }

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/exercise/parsed.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "author": "SebaRaba",
+    "levels": [
+      "beginner",
+      "basic",
+      "medium"
+    ],
+    "tags": [
+      "introduction",
+      "workout"
+    ],
+    "type": "exercise",
+    "linkType": "sqlfiddle",
+    "link": "http://sqlfiddle.com/#!9/d5ccaa",
+    "standards": {
+      "sql.define-columns.1": 1000,
+      "sql.define-columns.2": 1000
+    },
+    "links": [
+      {
+        "name": "mysql modify columns documentation",
+        "url": "https://dev.mysql.com/doc/refman/5.7/en/alter-table.html",
+        "nature": "website"
+      },
+      {
+        "name": "blog post on mysql define tables",
+        "url": "https://www.w3schools.com/sql/sql_alter.asp",
+        "nature": "website"
+      },
+      {
+        "name": "video tutorial on alter table",
+        "url": "https://youtu.be/vDr2DZeU5mY?t=50s",
+        "nature": "video"
+      }
+    ]
+  },
+  "headline": "SQL Practice Aggregate Average",
+  "exercise": "Follow the link to SQLFiddle and examine the `CREATE` statements in the lefthand window.\n\nConsider the `item_pictures` table. It turns out the maxiumum length of the `URL` field is much too short to hold mosts urls.\n\nUnfortunately, the schema is already in production, so re-creating the database is not an option.\n\nWrite a statement to modify the `item_pictures` table to adapt to the problem presented.  \nDon't directly edit the `CREATE` statements; instead, write a new statement to alter (*hint*) the table.\n\nTo submit, run your SQL and then add the link from SQLFiddle to your submission.  \n"
+}

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
@@ -3,7 +3,7 @@
   "children": [
     {
       "type": "yaml",
-      "value": "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n  - '[Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}'\n\nparent: removing-keys-from-a-binary-search-tree\n",
+      "value": "author: catalin\n\nlevels:\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\n\ntags:\n  - introduction\n  - workout\n\nstub: false\n\nlinks:\n  - '[EnkiCool](https://enki.com){website}'\n",
       "position": {
         "start": {
           "line": 1,
@@ -11,11 +11,17 @@
           "offset": 0
         },
         "end": {
-          "line": 20,
+          "line": 26,
           "column": 4,
-          "offset": 307
+          "offset": 257
         },
         "indent": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
           1,
           1,
           1,
@@ -39,23 +45,30 @@
       },
       "data": {
         "parsedValue": {
-          "author": "jfarmer",
+          "author": "catalin",
           "levels": [
-            "beginner",
             "basic",
             "medium",
             "advanced"
           ],
           "type": "normal",
           "category": "must-know",
+          "standards": {
+            "sql.use-dql.0": 10,
+            "sql.use-ddl.1": 1000
+          },
+          "tags": [
+            "introduction",
+            "workout"
+          ],
+          "stub": false,
           "links": [
             {
-              "name": "Why is it safer to keep the tree balanced?",
-              "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
+              "name": "EnkiCool",
+              "url": "https://enki.com",
               "nature": "website"
             }
-          ],
-          "parent": "removing-keys-from-a-binary-search-tree"
+          ]
         }
       }
     },
@@ -64,51 +77,51 @@
       "children": [
         {
           "type": "text",
-          "value": "Balanced vs. ",
+          "value": "Sample title with ",
           "position": {
             "start": {
-              "line": 21,
+              "line": 27,
               "column": 3,
-              "offset": 310
+              "offset": 260
             },
             "end": {
-              "line": 21,
-              "column": 16,
-              "offset": 323
+              "line": 27,
+              "column": 21,
+              "offset": 278
             },
             "indent": []
           }
         },
         {
           "type": "inlineCode",
-          "value": "Unbalanced",
+          "value": "code",
           "position": {
             "start": {
-              "line": 21,
-              "column": 16,
-              "offset": 323
+              "line": 27,
+              "column": 21,
+              "offset": 278
             },
             "end": {
-              "line": 21,
-              "column": 28,
-              "offset": 335
+              "line": 27,
+              "column": 27,
+              "offset": 284
             },
             "indent": []
           }
         },
         {
           "type": "text",
-          "value": " Binary Trees",
+          "value": " within",
           "position": {
             "start": {
-              "line": 21,
-              "column": 28,
-              "offset": 335
+              "line": 27,
+              "column": 27,
+              "offset": 284
             },
             "end": {
-              "line": 21,
-              "column": 41,
-              "offset": 348
+              "line": 27,
+              "column": 34,
+              "offset": 291
             },
             "indent": []
           }
@@ -124,406 +137,17 @@
           "children": [
             {
               "type": "text",
-              "value": "A binary tree is called ",
-              "position": {
-                "start": {
-                  "line": 26,
-                  "column": 1,
-                  "offset": 366
-                },
-                "end": {
-                  "line": 26,
-                  "column": 25,
-                  "offset": 390
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "emphasis",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "balanced",
-                  "position": {
-                    "start": {
-                      "line": 26,
-                      "column": 26,
-                      "offset": 391
-                    },
-                    "end": {
-                      "line": 26,
-                      "column": 34,
-                      "offset": 399
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 26,
-                  "column": 25,
-                  "offset": 390
-                },
-                "end": {
-                  "line": 26,
-                  "column": 35,
-                  "offset": 400
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application.",
-              "position": {
-                "start": {
-                  "line": 26,
-                  "column": 35,
-                  "offset": 400
-                },
-                "end": {
-                  "line": 26,
-                  "column": 441,
-                  "offset": 806
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 26,
-              "column": 1,
-              "offset": 366
-            },
-            "end": {
-              "line": 26,
-              "column": 441,
-              "offset": 806
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree.",
-              "position": {
-                "start": {
-                  "line": 28,
-                  "column": 1,
-                  "offset": 808
-                },
-                "end": {
-                  "line": 28,
-                  "column": 201,
-                  "offset": 1008
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 28,
-              "column": 1,
-              "offset": 808
-            },
-            "end": {
-              "line": 28,
-              "column": 201,
-              "offset": 1008
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:",
-              "position": {
-                "start": {
-                  "line": 30,
-                  "column": 1,
-                  "offset": 1010
-                },
-                "end": {
-                  "line": 30,
-                  "column": 107,
-                  "offset": 1116
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 30,
-              "column": 1,
-              "offset": 1010
-            },
-            "end": {
-              "line": 30,
-              "column": 107,
-              "offset": 1116
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "image",
-              "title": null,
-              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
-              "alt": "unbalanced",
+              "value": "This is a sample paragraph.",
               "position": {
                 "start": {
                   "line": 32,
                   "column": 1,
-                  "offset": 1118
+                  "offset": 309
                 },
                 "end": {
                   "line": 32,
-                  "column": 3539,
-                  "offset": 4656
-                },
-                "indent": []
-              },
-              "svg": true
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 32,
-              "column": 1,
-              "offset": 1118
-            },
-            "end": {
-              "line": 32,
-              "column": 3539,
-              "offset": 4656
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "In order to balance the above tree, the ",
-              "position": {
-                "start": {
-                  "line": 34,
-                  "column": 1,
-                  "offset": 4658
-                },
-                "end": {
-                  "line": 34,
-                  "column": 41,
-                  "offset": 4698
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "inlineCode",
-              "value": "10-15-13",
-              "position": {
-                "start": {
-                  "line": 34,
-                  "column": 41,
-                  "offset": 4698
-                },
-                "end": {
-                  "line": 34,
-                  "column": 51,
-                  "offset": 4708
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " subtree has to be \"rotated\":",
-              "position": {
-                "start": {
-                  "line": 34,
-                  "column": 51,
-                  "offset": 4708
-                },
-                "end": {
-                  "line": 34,
-                  "column": 80,
-                  "offset": 4737
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 34,
-              "column": 1,
-              "offset": 4658
-            },
-            "end": {
-              "line": 34,
-              "column": 80,
-              "offset": 4737
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "image",
-              "title": null,
-              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
-              "alt": "balanced",
-              "position": {
-                "start": {
-                  "line": 36,
-                  "column": 1,
-                  "offset": 4739
-                },
-                "end": {
-                  "line": 36,
-                  "column": 3537,
-                  "offset": 8275
-                },
-                "indent": []
-              },
-              "svg": true
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 36,
-              "column": 1,
-              "offset": 4739
-            },
-            "end": {
-              "line": 36,
-              "column": 3537,
-              "offset": 8275
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching ",
-              "position": {
-                "start": {
-                  "line": 39,
-                  "column": 1,
-                  "offset": 8278
-                },
-                "end": {
-                  "line": 39,
-                  "column": 153,
-                  "offset": 8430
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "emphasis",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "on average",
-                  "position": {
-                    "start": {
-                      "line": 39,
-                      "column": 154,
-                      "offset": 8431
-                    },
-                    "end": {
-                      "line": 39,
-                      "column": 164,
-                      "offset": 8441
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 39,
-                  "column": 153,
-                  "offset": 8430
-                },
-                "end": {
-                  "line": 39,
-                  "column": 165,
-                  "offset": 8442
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": ", but a linear-time worst case.",
-              "position": {
-                "start": {
-                  "line": 39,
-                  "column": 165,
-                  "offset": 8442
-                },
-                "end": {
-                  "line": 39,
-                  "column": 196,
-                  "offset": 8473
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 39,
-              "column": 1,
-              "offset": 8278
-            },
-            "end": {
-              "line": 39,
-              "column": 196,
-              "offset": 8473
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees",
-              "position": {
-                "start": {
-                  "line": 41,
-                  "column": 1,
-                  "offset": 8475
-                },
-                "end": {
-                  "line": 41,
-                  "column": 174,
-                  "offset": 8648
+                  "column": 28,
+                  "offset": 336
                 },
                 "indent": []
               }
@@ -538,14 +162,14 @@
                   "value": "1",
                   "position": {
                     "start": {
-                      "line": 41,
-                      "column": 175,
-                      "offset": 8649
+                      "line": 32,
+                      "column": 29,
+                      "offset": 337
                     },
                     "end": {
-                      "line": 41,
-                      "column": 176,
-                      "offset": 8650
+                      "line": 32,
+                      "column": 30,
+                      "offset": 338
                     },
                     "indent": []
                   }
@@ -553,31 +177,49 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
-                  "column": 174,
-                  "offset": 8648
+                  "line": 32,
+                  "column": 28,
+                  "offset": 336
                 },
                 "end": {
-                  "line": 41,
-                  "column": 177,
-                  "offset": 8651
+                  "line": 32,
+                  "column": 31,
+                  "offset": 339
                 },
                 "indent": []
               }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 32,
+              "column": 1,
+              "offset": 309
             },
+            "end": {
+              "line": 32,
+              "column": 31,
+              "offset": 339
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
             {
               "type": "text",
-              "value": " and red-black trees",
+              "value": "This is a sample list",
               "position": {
                 "start": {
-                  "line": 41,
-                  "column": 177,
-                  "offset": 8651
+                  "line": 34,
+                  "column": 1,
+                  "offset": 341
                 },
                 "end": {
-                  "line": 41,
-                  "column": 197,
-                  "offset": 8671
+                  "line": 34,
+                  "column": 22,
+                  "offset": 362
                 },
                 "indent": []
               }
@@ -592,14 +234,14 @@
                   "value": "2",
                   "position": {
                     "start": {
-                      "line": 41,
-                      "column": 198,
-                      "offset": 8672
+                      "line": 34,
+                      "column": 23,
+                      "offset": 363
                     },
                     "end": {
-                      "line": 41,
-                      "column": 199,
-                      "offset": 8673
+                      "line": 34,
+                      "column": 24,
+                      "offset": 364
                     },
                     "indent": []
                   }
@@ -607,31 +249,31 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
-                  "column": 197,
-                  "offset": 8671
+                  "line": 34,
+                  "column": 22,
+                  "offset": 362
                 },
                 "end": {
-                  "line": 41,
-                  "column": 200,
-                  "offset": 8674
+                  "line": 34,
+                  "column": 25,
+                  "offset": 365
                 },
                 "indent": []
               }
             },
             {
               "type": "text",
-              "value": ".",
+              "value": ":",
               "position": {
                 "start": {
-                  "line": 41,
-                  "column": 200,
-                  "offset": 8674
+                  "line": 34,
+                  "column": 25,
+                  "offset": 365
                 },
                 "end": {
-                  "line": 41,
-                  "column": 201,
-                  "offset": 8675
+                  "line": 34,
+                  "column": 26,
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -639,101 +281,17 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 34,
               "column": 1,
-              "offset": 8475
+              "offset": 341
             },
             "end": {
-              "line": 41,
-              "column": 201,
-              "offset": 8675
+              "line": 34,
+              "column": 26,
+              "offset": 366
             },
             "indent": []
           }
-        }
-      ]
-    },
-    {
-      "type": "section",
-      "name": "Practice",
-      "children": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "Blah blah blah",
-              "position": {
-                "start": {
-                  "line": 46,
-                  "column": 1,
-                  "offset": 8694
-                },
-                "end": {
-                  "line": 46,
-                  "column": 15,
-                  "offset": 8708
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 46,
-              "column": 1,
-              "offset": 8694
-            },
-            "end": {
-              "line": 46,
-              "column": 15,
-              "offset": 8708
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "questionCode",
-          "lang": "javascript",
-          "value": "Blah blah\n???",
-          "position": {
-            "start": {
-              "line": 48,
-              "column": 1,
-              "offset": 8710
-            },
-            "end": {
-              "line": 51,
-              "column": 4,
-              "offset": 8741
-            },
-            "indent": [
-              1,
-              1,
-              1
-            ]
-          },
-          "children": [
-            {
-              "type": "questionCodeLine",
-              "children": [
-                {
-                  "lang": "javascript",
-                  "type": "questionCodeSegment",
-                  "value": "Blah blah"
-                }
-              ]
-            },
-            {
-              "type": "questionCodeLine",
-              "children": [
-                {
-                  "type": "questionGap",
-                  "value": "???"
-                }
-              ]
-            }
-          ]
         },
         {
           "type": "list",
@@ -751,17 +309,17 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "abc",
+                      "value": "item one",
                       "position": {
                         "start": {
-                          "line": 53,
+                          "line": 36,
                           "column": 3,
-                          "offset": 8745
+                          "offset": 370
                         },
                         "end": {
-                          "line": 53,
-                          "column": 6,
-                          "offset": 8748
+                          "line": 36,
+                          "column": 11,
+                          "offset": 378
                         },
                         "indent": []
                       }
@@ -769,14 +327,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 53,
+                      "line": 36,
                       "column": 3,
-                      "offset": 8745
+                      "offset": 370
                     },
                     "end": {
-                      "line": 53,
-                      "column": 6,
-                      "offset": 8748
+                      "line": 36,
+                      "column": 11,
+                      "offset": 378
                     },
                     "indent": []
                   }
@@ -784,18 +342,17 @@
               ],
               "position": {
                 "start": {
-                  "line": 53,
+                  "line": 36,
                   "column": 1,
-                  "offset": 8743
+                  "offset": 368
                 },
                 "end": {
-                  "line": 53,
-                  "column": 6,
-                  "offset": 8748
+                  "line": 36,
+                  "column": 11,
+                  "offset": 378
                 },
                 "indent": []
-              },
-              "correct": true
+              }
             },
             {
               "type": "listItem",
@@ -807,73 +364,34 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "yoli",
+                      "value": "item ",
                       "position": {
                         "start": {
-                          "line": 54,
+                          "line": 37,
                           "column": 3,
-                          "offset": 8751
+                          "offset": 381
                         },
                         "end": {
-                          "line": 54,
-                          "column": 7,
-                          "offset": 8755
+                          "line": 37,
+                          "column": 8,
+                          "offset": 386
                         },
                         "indent": []
                       }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 54,
-                      "column": 3,
-                      "offset": 8751
                     },
-                    "end": {
-                      "line": 54,
-                      "column": 7,
-                      "offset": 8755
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 54,
-                  "column": 1,
-                  "offset": 8749
-                },
-                "end": {
-                  "line": 54,
-                  "column": 7,
-                  "offset": 8755
-                },
-                "indent": []
-              },
-              "correct": true
-            },
-            {
-              "type": "listItem",
-              "loose": false,
-              "checked": null,
-              "children": [
-                {
-                  "type": "paragraph",
-                  "children": [
                     {
-                      "type": "text",
-                      "value": "yes",
+                      "type": "inlineCode",
+                      "value": "two",
                       "position": {
                         "start": {
-                          "line": 55,
-                          "column": 3,
-                          "offset": 8758
+                          "line": 37,
+                          "column": 8,
+                          "offset": 386
                         },
                         "end": {
-                          "line": 55,
-                          "column": 6,
-                          "offset": 8761
+                          "line": 37,
+                          "column": 13,
+                          "offset": 391
                         },
                         "indent": []
                       }
@@ -881,14 +399,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 55,
+                      "line": 37,
                       "column": 3,
-                      "offset": 8758
+                      "offset": 381
                     },
                     "end": {
-                      "line": 55,
-                      "column": 6,
-                      "offset": 8761
+                      "line": 37,
+                      "column": 13,
+                      "offset": 391
                     },
                     "indent": []
                   }
@@ -896,30 +414,406 @@
               ],
               "position": {
                 "start": {
-                  "line": 55,
+                  "line": 37,
                   "column": 1,
-                  "offset": 8756
+                  "offset": 379
                 },
                 "end": {
-                  "line": 55,
-                  "column": 6,
-                  "offset": 8761
+                  "line": 37,
+                  "column": 13,
+                  "offset": 391
                 },
                 "indent": []
-              },
-              "correct": false
+              }
             }
           ],
           "position": {
             "start": {
-              "line": 53,
+              "line": 36,
               "column": 1,
-              "offset": 8743
+              "offset": 368
             },
             "end": {
-              "line": 55,
-              "column": 6,
-              "offset": 8761
+              "line": 37,
+              "column": 13,
+              "offset": 391
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Sample code",
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 1,
+                  "offset": 393
+                },
+                "end": {
+                  "line": 39,
+                  "column": 12,
+                  "offset": 404
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "linkReference",
+              "identifier": "3",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "3",
+                  "position": {
+                    "start": {
+                      "line": 39,
+                      "column": 13,
+                      "offset": 405
+                    },
+                    "end": {
+                      "line": 39,
+                      "column": 14,
+                      "offset": 406
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 12,
+                  "offset": 404
+                },
+                "end": {
+                  "line": 39,
+                  "column": 15,
+                  "offset": 407
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": ":",
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 15,
+                  "offset": 407
+                },
+                "end": {
+                  "line": 39,
+                  "column": 16,
+                  "offset": 408
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 39,
+              "column": 1,
+              "offset": 393
+            },
+            "end": {
+              "line": 39,
+              "column": 16,
+              "offset": 408
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "code",
+          "lang": "javascript",
+          "value": "console.log('sample code')",
+          "position": {
+            "start": {
+              "line": 40,
+              "column": 1,
+              "offset": 409
+            },
+            "end": {
+              "line": 42,
+              "column": 4,
+              "offset": 453
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "name": "Practice",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This is a sample question with one gap:",
+              "position": {
+                "start": {
+                  "line": 47,
+                  "column": 1,
+                  "offset": 472
+                },
+                "end": {
+                  "line": 47,
+                  "column": 40,
+                  "offset": 511
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 47,
+              "column": 1,
+              "offset": 472
+            },
+            "end": {
+              "line": 47,
+              "column": 40,
+              "offset": 511
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "questionGap",
+              "value": "???",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 1,
+                  "offset": 513
+                },
+                "end": {
+                  "line": 49,
+                  "column": 4,
+                  "offset": 516
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 1,
+              "offset": 513
+            },
+            "end": {
+              "line": 49,
+              "column": 4,
+              "offset": 516
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "loose": false,
+          "children": [
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "correct",
+                      "position": {
+                        "start": {
+                          "line": 51,
+                          "column": 3,
+                          "offset": 520
+                        },
+                        "end": {
+                          "line": 51,
+                          "column": 10,
+                          "offset": 527
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 51,
+                      "column": 3,
+                      "offset": 520
+                    },
+                    "end": {
+                      "line": 51,
+                      "column": 10,
+                      "offset": 527
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 51,
+                  "column": 1,
+                  "offset": 518
+                },
+                "end": {
+                  "line": 51,
+                  "column": 10,
+                  "offset": 527
+                },
+                "indent": []
+              },
+              "correct": true
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "incorrect",
+                      "position": {
+                        "start": {
+                          "line": 52,
+                          "column": 3,
+                          "offset": 530
+                        },
+                        "end": {
+                          "line": 52,
+                          "column": 12,
+                          "offset": 539
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 52,
+                      "column": 3,
+                      "offset": 530
+                    },
+                    "end": {
+                      "line": 52,
+                      "column": 12,
+                      "offset": 539
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 52,
+                  "column": 1,
+                  "offset": 528
+                },
+                "end": {
+                  "line": 52,
+                  "column": 12,
+                  "offset": 539
+                },
+                "indent": []
+              },
+              "correct": true
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "not a chance",
+                      "position": {
+                        "start": {
+                          "line": 53,
+                          "column": 3,
+                          "offset": 542
+                        },
+                        "end": {
+                          "line": 53,
+                          "column": 15,
+                          "offset": 554
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 53,
+                      "column": 3,
+                      "offset": 542
+                    },
+                    "end": {
+                      "line": 53,
+                      "column": 15,
+                      "offset": 554
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 53,
+                  "column": 1,
+                  "offset": 540
+                },
+                "end": {
+                  "line": 53,
+                  "column": 15,
+                  "offset": 554
+                },
+                "indent": []
+              },
+              "correct": true
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 51,
+              "column": 1,
+              "offset": 518
+            },
+            "end": {
+              "line": 53,
+              "column": 15,
+              "offset": 554
             },
             "indent": [
               1,
@@ -940,69 +834,52 @@
           "children": [
             {
               "type": "text",
-              "value": "Which of the following data structures is a type of ",
+              "value": "This is a sample question with two gaps:",
+              "position": {
+                "start": {
+                  "line": 58,
+                  "column": 1,
+                  "offset": 573
+                },
+                "end": {
+                  "line": 58,
+                  "column": 41,
+                  "offset": 613
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 58,
+              "column": 1,
+              "offset": 573
+            },
+            "end": {
+              "line": 58,
+              "column": 41,
+              "offset": 613
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "questionGap",
+              "value": "???",
               "position": {
                 "start": {
                   "line": 60,
                   "column": 1,
-                  "offset": 8780
+                  "offset": 615
                 },
                 "end": {
                   "line": 60,
-                  "column": 53,
-                  "offset": 8832
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "emphasis",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "maximally-unbalanced",
-                  "position": {
-                    "start": {
-                      "line": 60,
-                      "column": 54,
-                      "offset": 8833
-                    },
-                    "end": {
-                      "line": 60,
-                      "column": 74,
-                      "offset": 8853
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 60,
-                  "column": 53,
-                  "offset": 8832
-                },
-                "end": {
-                  "line": 60,
-                  "column": 75,
-                  "offset": 8854
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " binary tree?",
-              "position": {
-                "start": {
-                  "line": 60,
-                  "column": 75,
-                  "offset": 8854
-                },
-                "end": {
-                  "line": 60,
-                  "column": 88,
-                  "offset": 8867
+                  "column": 4,
+                  "offset": 618
                 },
                 "indent": []
               }
@@ -1012,12 +889,12 @@
             "start": {
               "line": 60,
               "column": 1,
-              "offset": 8780
+              "offset": 615
             },
             "end": {
               "line": 60,
-              "column": 88,
-              "offset": 8867
+              "column": 4,
+              "offset": 618
             },
             "indent": []
           }
@@ -1032,12 +909,12 @@
                 "start": {
                   "line": 62,
                   "column": 1,
-                  "offset": 8869
+                  "offset": 620
                 },
                 "end": {
                   "line": 62,
                   "column": 4,
-                  "offset": 8872
+                  "offset": 623
                 },
                 "indent": []
               }
@@ -1047,12 +924,12 @@
             "start": {
               "line": 62,
               "column": 1,
-              "offset": 8869
+              "offset": 620
             },
             "end": {
               "line": 62,
               "column": 4,
-              "offset": 8872
+              "offset": 623
             },
             "indent": []
           }
@@ -1073,17 +950,17 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "Ordered linked list",
+                      "value": "correct",
                       "position": {
                         "start": {
                           "line": 64,
                           "column": 3,
-                          "offset": 8876
+                          "offset": 627
                         },
                         "end": {
                           "line": 64,
-                          "column": 22,
-                          "offset": 8895
+                          "column": 10,
+                          "offset": 634
                         },
                         "indent": []
                       }
@@ -1093,12 +970,12 @@
                     "start": {
                       "line": 64,
                       "column": 3,
-                      "offset": 8876
+                      "offset": 627
                     },
                     "end": {
                       "line": 64,
-                      "column": 22,
-                      "offset": 8895
+                      "column": 10,
+                      "offset": 634
                     },
                     "indent": []
                   }
@@ -1108,16 +985,16 @@
                 "start": {
                   "line": 64,
                   "column": 1,
-                  "offset": 8874
+                  "offset": 625
                 },
                 "end": {
                   "line": 64,
-                  "column": 22,
-                  "offset": 8895
+                  "column": 10,
+                  "offset": 634
                 },
                 "indent": []
               },
-              "correct": false
+              "correct": true
             },
             {
               "type": "listItem",
@@ -1129,17 +1006,17 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "Ordered array",
+                      "value": "also correct",
                       "position": {
                         "start": {
                           "line": 65,
                           "column": 3,
-                          "offset": 8898
+                          "offset": 637
                         },
                         "end": {
                           "line": 65,
-                          "column": 16,
-                          "offset": 8911
+                          "column": 15,
+                          "offset": 649
                         },
                         "indent": []
                       }
@@ -1149,12 +1026,12 @@
                     "start": {
                       "line": 65,
                       "column": 3,
-                      "offset": 8898
+                      "offset": 637
                     },
                     "end": {
                       "line": 65,
-                      "column": 16,
-                      "offset": 8911
+                      "column": 15,
+                      "offset": 649
                     },
                     "indent": []
                   }
@@ -1164,12 +1041,12 @@
                 "start": {
                   "line": 65,
                   "column": 1,
-                  "offset": 8896
+                  "offset": 635
                 },
                 "end": {
                   "line": 65,
-                  "column": 16,
-                  "offset": 8911
+                  "column": 15,
+                  "offset": 649
                 },
                 "indent": []
               },
@@ -1185,17 +1062,17 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "Weighted graph",
+                      "value": "nah bro",
                       "position": {
                         "start": {
                           "line": 66,
                           "column": 3,
-                          "offset": 8914
+                          "offset": 652
                         },
                         "end": {
                           "line": 66,
-                          "column": 17,
-                          "offset": 8928
+                          "column": 10,
+                          "offset": 659
                         },
                         "indent": []
                       }
@@ -1205,12 +1082,12 @@
                     "start": {
                       "line": 66,
                       "column": 3,
-                      "offset": 8914
+                      "offset": 652
                     },
                     "end": {
                       "line": 66,
-                      "column": 17,
-                      "offset": 8928
+                      "column": 10,
+                      "offset": 659
                     },
                     "indent": []
                   }
@@ -1220,12 +1097,12 @@
                 "start": {
                   "line": 66,
                   "column": 1,
-                  "offset": 8912
+                  "offset": 650
                 },
                 "end": {
                   "line": 66,
-                  "column": 17,
-                  "offset": 8928
+                  "column": 10,
+                  "offset": 659
                 },
                 "indent": []
               },
@@ -1241,17 +1118,17 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "Max-heap",
+                      "value": "fam, just no",
                       "position": {
                         "start": {
                           "line": 67,
                           "column": 3,
-                          "offset": 8931
+                          "offset": 662
                         },
                         "end": {
                           "line": 67,
-                          "column": 11,
-                          "offset": 8939
+                          "column": 15,
+                          "offset": 674
                         },
                         "indent": []
                       }
@@ -1261,12 +1138,12 @@
                     "start": {
                       "line": 67,
                       "column": 3,
-                      "offset": 8931
+                      "offset": 662
                     },
                     "end": {
                       "line": 67,
-                      "column": 11,
-                      "offset": 8939
+                      "column": 15,
+                      "offset": 674
                     },
                     "indent": []
                   }
@@ -1276,12 +1153,12 @@
                 "start": {
                   "line": 67,
                   "column": 1,
-                  "offset": 8929
+                  "offset": 660
                 },
                 "end": {
                   "line": 67,
-                  "column": 11,
-                  "offset": 8939
+                  "column": 15,
+                  "offset": 674
                 },
                 "indent": []
               },
@@ -1292,12 +1169,12 @@
             "start": {
               "line": 64,
               "column": 1,
-              "offset": 8874
+              "offset": 625
             },
             "end": {
               "line": 67,
-              "column": 11,
-              "offset": 8939
+              "column": 15,
+              "offset": 674
             },
             "indent": [
               1,
@@ -1319,51 +1196,17 @@
           "children": [
             {
               "type": "text",
-              "value": "what is the output of ",
+              "value": "Quiz title",
               "position": {
                 "start": {
                   "line": 72,
                   "column": 5,
-                  "offset": 8958
+                  "offset": 693
                 },
                 "end": {
                   "line": 72,
-                  "column": 27,
-                  "offset": 8980
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "inlineCode",
-              "value": "the",
-              "position": {
-                "start": {
-                  "line": 72,
-                  "column": 27,
-                  "offset": 8980
-                },
-                "end": {
-                  "line": 72,
-                  "column": 32,
-                  "offset": 8985
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": " following script?",
-              "position": {
-                "start": {
-                  "line": 72,
-                  "column": 32,
-                  "offset": 8985
-                },
-                "end": {
-                  "line": 72,
-                  "column": 50,
-                  "offset": 9003
+                  "column": 15,
+                  "offset": 703
                 },
                 "indent": []
               }
@@ -1371,45 +1214,21 @@
           ]
         },
         {
-          "type": "code",
-          "lang": "bash",
-          "value": "#!/bin/bash\na=1\n{ a=2 }\necho $a",
-          "position": {
-            "start": {
-              "line": 74,
-              "column": 1,
-              "offset": 9005
-            },
-            "end": {
-              "line": 79,
-              "column": 4,
-              "offset": 9048
-            },
-            "indent": [
-              1,
-              1,
-              1,
-              1,
-              1
-            ]
-          }
-        },
-        {
           "type": "paragraph",
           "children": [
             {
               "type": "text",
-              "value": "There is a list here:",
+              "value": "Sample quiz question",
               "position": {
                 "start": {
-                  "line": 81,
+                  "line": 74,
                   "column": 1,
-                  "offset": 9050
+                  "offset": 705
                 },
                 "end": {
-                  "line": 81,
-                  "column": 22,
-                  "offset": 9071
+                  "line": 74,
+                  "column": 21,
+                  "offset": 725
                 },
                 "indent": []
               }
@@ -1417,14 +1236,14 @@
           ],
           "position": {
             "start": {
-              "line": 81,
+              "line": 74,
               "column": 1,
-              "offset": 9050
+              "offset": 705
             },
             "end": {
-              "line": 81,
-              "column": 22,
-              "offset": 9071
+              "line": 74,
+              "column": 21,
+              "offset": 725
             },
             "indent": []
           }
@@ -1445,17 +1264,17 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "abc",
+                      "value": "correct",
                       "position": {
                         "start": {
-                          "line": 82,
+                          "line": 76,
                           "column": 3,
-                          "offset": 9074
+                          "offset": 729
                         },
                         "end": {
-                          "line": 82,
-                          "column": 6,
-                          "offset": 9077
+                          "line": 76,
+                          "column": 10,
+                          "offset": 736
                         },
                         "indent": []
                       }
@@ -1463,14 +1282,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 82,
+                      "line": 76,
                       "column": 3,
-                      "offset": 9074
+                      "offset": 729
                     },
                     "end": {
-                      "line": 82,
-                      "column": 6,
-                      "offset": 9077
+                      "line": 76,
+                      "column": 10,
+                      "offset": 736
                     },
                     "indent": []
                   }
@@ -1478,17 +1297,18 @@
               ],
               "position": {
                 "start": {
-                  "line": 82,
+                  "line": 76,
                   "column": 1,
-                  "offset": 9072
+                  "offset": 727
                 },
                 "end": {
-                  "line": 82,
-                  "column": 6,
-                  "offset": 9077
+                  "line": 76,
+                  "column": 10,
+                  "offset": 736
                 },
                 "indent": []
-              }
+              },
+              "correct": true
             },
             {
               "type": "listItem",
@@ -1499,18 +1319,36 @@
                   "type": "paragraph",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "def",
+                      "type": "emphasis",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "incorrect",
+                          "position": {
+                            "start": {
+                              "line": 77,
+                              "column": 4,
+                              "offset": 740
+                            },
+                            "end": {
+                              "line": 77,
+                              "column": 13,
+                              "offset": 749
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
                       "position": {
                         "start": {
-                          "line": 83,
+                          "line": 77,
                           "column": 3,
-                          "offset": 9080
+                          "offset": 739
                         },
                         "end": {
-                          "line": 83,
-                          "column": 6,
-                          "offset": 9083
+                          "line": 77,
+                          "column": 14,
+                          "offset": 750
                         },
                         "indent": []
                       }
@@ -1518,14 +1356,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 83,
+                      "line": 77,
                       "column": 3,
-                      "offset": 9080
+                      "offset": 739
                     },
                     "end": {
-                      "line": 83,
-                      "column": 6,
-                      "offset": 9083
+                      "line": 77,
+                      "column": 14,
+                      "offset": 750
                     },
                     "indent": []
                   }
@@ -1533,148 +1371,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 83,
+                  "line": 77,
                   "column": 1,
-                  "offset": 9078
+                  "offset": 737
                 },
                 "end": {
-                  "line": 83,
-                  "column": 6,
-                  "offset": 9083
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "listItem",
-              "loose": false,
-              "checked": null,
-              "children": [
-                {
-                  "type": "paragraph",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "abcd",
-                      "position": {
-                        "start": {
-                          "line": 84,
-                          "column": 3,
-                          "offset": 9086
-                        },
-                        "end": {
-                          "line": 84,
-                          "column": 7,
-                          "offset": 9090
-                        },
-                        "indent": []
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 84,
-                      "column": 3,
-                      "offset": 9086
-                    },
-                    "end": {
-                      "line": 84,
-                      "column": 7,
-                      "offset": 9090
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 84,
-                  "column": 1,
-                  "offset": 9084
-                },
-                "end": {
-                  "line": 84,
-                  "column": 7,
-                  "offset": 9090
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 82,
-              "column": 1,
-              "offset": 9072
-            },
-            "end": {
-              "line": 84,
-              "column": 7,
-              "offset": 9090
-            },
-            "indent": [
-              1,
-              1
-            ]
-          }
-        },
-        {
-          "type": "list",
-          "ordered": false,
-          "start": null,
-          "loose": false,
-          "children": [
-            {
-              "type": "listItem",
-              "loose": false,
-              "checked": null,
-              "children": [
-                {
-                  "type": "paragraph",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "\"Error: unexpected end of file\"",
-                      "position": {
-                        "start": {
-                          "line": 86,
-                          "column": 3,
-                          "offset": 9094
-                        },
-                        "end": {
-                          "line": 86,
-                          "column": 34,
-                          "offset": 9125
-                        },
-                        "indent": []
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 86,
-                      "column": 3,
-                      "offset": 9094
-                    },
-                    "end": {
-                      "line": 86,
-                      "column": 34,
-                      "offset": 9125
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 86,
-                  "column": 1,
-                  "offset": 9092
-                },
-                "end": {
-                  "line": 86,
-                  "column": 34,
-                  "offset": 9125
+                  "line": 77,
+                  "column": 14,
+                  "offset": 750
                 },
                 "indent": []
               },
@@ -1688,19 +1392,36 @@
                 {
                   "type": "paragraph",
                   "children": [
+                    {
+                      "type": "text",
+                      "value": "not a ",
+                      "position": {
+                        "start": {
+                          "line": 78,
+                          "column": 3,
+                          "offset": 753
+                        },
+                        "end": {
+                          "line": 78,
+                          "column": 9,
+                          "offset": 759
+                        },
+                        "indent": []
+                      }
+                    },
                     {
                       "type": "inlineCode",
-                      "value": "1",
+                      "value": "chance",
                       "position": {
                         "start": {
-                          "line": 87,
-                          "column": 3,
-                          "offset": 9128
+                          "line": 78,
+                          "column": 9,
+                          "offset": 759
                         },
                         "end": {
-                          "line": 87,
-                          "column": 6,
-                          "offset": 9131
+                          "line": 78,
+                          "column": 17,
+                          "offset": 767
                         },
                         "indent": []
                       }
@@ -1708,14 +1429,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 87,
+                      "line": 78,
                       "column": 3,
-                      "offset": 9128
+                      "offset": 753
                     },
                     "end": {
-                      "line": 87,
-                      "column": 6,
-                      "offset": 9131
+                      "line": 78,
+                      "column": 17,
+                      "offset": 767
                     },
                     "indent": []
                   }
@@ -1723,14 +1444,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 87,
+                  "line": 78,
                   "column": 1,
-                  "offset": 9126
+                  "offset": 751
                 },
                 "end": {
-                  "line": 87,
-                  "column": 6,
-                  "offset": 9131
+                  "line": 78,
+                  "column": 17,
+                  "offset": 767
                 },
                 "indent": []
               },
@@ -1746,17 +1467,17 @@
                   "children": [
                     {
                       "type": "text",
-                      "value": "2",
+                      "value": "nope",
                       "position": {
                         "start": {
-                          "line": 88,
+                          "line": 79,
                           "column": 3,
-                          "offset": 9134
+                          "offset": 770
                         },
                         "end": {
-                          "line": 88,
-                          "column": 4,
-                          "offset": 9135
+                          "line": 79,
+                          "column": 7,
+                          "offset": 774
                         },
                         "indent": []
                       }
@@ -1764,14 +1485,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 88,
+                      "line": 79,
                       "column": 3,
-                      "offset": 9134
+                      "offset": 770
                     },
                     "end": {
-                      "line": 88,
-                      "column": 4,
-                      "offset": 9135
+                      "line": 79,
+                      "column": 7,
+                      "offset": 774
                     },
                     "indent": []
                   }
@@ -1779,70 +1500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 88,
+                  "line": 79,
                   "column": 1,
-                  "offset": 9132
+                  "offset": 768
                 },
                 "end": {
-                  "line": 88,
-                  "column": 4,
-                  "offset": 9135
-                },
-                "indent": []
-              },
-              "correct": false
-            },
-            {
-              "type": "listItem",
-              "loose": false,
-              "checked": null,
-              "children": [
-                {
-                  "type": "paragraph",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "$a",
-                      "position": {
-                        "start": {
-                          "line": 89,
-                          "column": 3,
-                          "offset": 9138
-                        },
-                        "end": {
-                          "line": 89,
-                          "column": 5,
-                          "offset": 9140
-                        },
-                        "indent": []
-                      }
-                    }
-                  ],
-                  "position": {
-                    "start": {
-                      "line": 89,
-                      "column": 3,
-                      "offset": 9138
-                    },
-                    "end": {
-                      "line": 89,
-                      "column": 5,
-                      "offset": 9140
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 89,
-                  "column": 1,
-                  "offset": 9136
-                },
-                "end": {
-                  "line": 89,
-                  "column": 5,
-                  "offset": 9140
+                  "line": 79,
+                  "column": 7,
+                  "offset": 774
                 },
                 "indent": []
               },
@@ -1851,14 +1516,14 @@
           ],
           "position": {
             "start": {
-              "line": 86,
+              "line": 76,
               "column": 1,
-              "offset": 9092
+              "offset": 727
             },
             "end": {
-              "line": 89,
-              "column": 5,
-              "offset": 9140
+              "line": 79,
+              "column": 7,
+              "offset": 774
             },
             "indent": [
               1,
@@ -1880,174 +1545,22 @@
           "children": [
             {
               "type": "linkReference",
-              "identifier": "1: avl tree",
+              "identifier": "1: paragraph",
               "referenceType": "shortcut",
               "children": [
                 {
                   "type": "text",
-                  "value": "1: AVL tree",
+                  "value": "1: Paragraph",
                   "position": {
                     "start": {
-                      "line": 94,
+                      "line": 84,
                       "column": 2,
-                      "offset": 9161
+                      "offset": 795
                     },
                     "end": {
-                      "line": 94,
-                      "column": 13,
-                      "offset": 9172
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 94,
-                  "column": 1,
-                  "offset": 9160
-                },
-                "end": {
-                  "line": 94,
-                  "column": 14,
-                  "offset": 9173
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.",
-              "position": {
-                "start": {
-                  "line": 94,
-                  "column": 14,
-                  "offset": 9173
-                },
-                "end": {
-                  "line": 95,
-                  "column": 116,
-                  "offset": 9289
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 94,
-              "column": 1,
-              "offset": 9160
-            },
-            "end": {
-              "line": 95,
-              "column": 116,
-              "offset": 9289
-            },
-            "indent": [
-              1
-            ]
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "linkReference",
-              "identifier": "2: red-black tree",
-              "referenceType": "shortcut",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "2: Red-Black tree",
-                  "position": {
-                    "start": {
-                      "line": 97,
-                      "column": 2,
-                      "offset": 9292
-                    },
-                    "end": {
-                      "line": 97,
-                      "column": 19,
-                      "offset": 9309
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 97,
-                  "column": 1,
-                  "offset": 9291
-                },
-                "end": {
-                  "line": 97,
-                  "column": 20,
-                  "offset": 9310
-                },
-                "indent": []
-              }
-            },
-            {
-              "type": "text",
-              "value": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.",
-              "position": {
-                "start": {
-                  "line": 97,
-                  "column": 20,
-                  "offset": 9310
-                },
-                "end": {
-                  "line": 98,
-                  "column": 222,
-                  "offset": 9532
-                },
-                "indent": [
-                  1
-                ]
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 97,
-              "column": 1,
-              "offset": 9291
-            },
-            "end": {
-              "line": 98,
-              "column": 222,
-              "offset": 9532
-            },
-            "indent": [
-              1
-            ]
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "linkReference",
-              "identifier": "3: blah blah",
-              "referenceType": "shortcut",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "3: Blah blah",
-                  "position": {
-                    "start": {
-                      "line": 100,
-                      "column": 2,
-                      "offset": 9535
-                    },
-                    "end": {
-                      "line": 100,
+                      "line": 84,
                       "column": 14,
-                      "offset": 9547
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -2055,31 +1568,31 @@
               ],
               "position": {
                 "start": {
-                  "line": 100,
+                  "line": 84,
                   "column": 1,
-                  "offset": 9534
+                  "offset": 794
                 },
                 "end": {
-                  "line": 100,
+                  "line": 84,
                   "column": 15,
-                  "offset": 9548
+                  "offset": 808
                 },
                 "indent": []
               }
             },
             {
               "type": "text",
-              "value": "\nThis is the third footnote",
+              "value": "\nSample explanation",
               "position": {
                 "start": {
-                  "line": 100,
+                  "line": 84,
                   "column": 15,
-                  "offset": 9548
+                  "offset": 808
                 },
                 "end": {
-                  "line": 101,
-                  "column": 27,
-                  "offset": 9575
+                  "line": 85,
+                  "column": 19,
+                  "offset": 827
                 },
                 "indent": [
                   1
@@ -2089,14 +1602,14 @@
           ],
           "position": {
             "start": {
-              "line": 100,
+              "line": 84,
               "column": 1,
-              "offset": 9534
+              "offset": 794
             },
             "end": {
-              "line": 101,
-              "column": 27,
-              "offset": 9575
+              "line": 85,
+              "column": 19,
+              "offset": 827
             },
             "indent": [
               1
@@ -2107,35 +1620,152 @@
           "type": "paragraph",
           "children": [
             {
-              "type": "text",
-              "value": "with code:",
+              "type": "linkReference",
+              "identifier": "2: list",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "2: List",
+                  "position": {
+                    "start": {
+                      "line": 87,
+                      "column": 2,
+                      "offset": 830
+                    },
+                    "end": {
+                      "line": 87,
+                      "column": 9,
+                      "offset": 837
+                    },
+                    "indent": []
+                  }
+                }
+              ],
               "position": {
                 "start": {
-                  "line": 103,
+                  "line": 87,
                   "column": 1,
-                  "offset": 9577
+                  "offset": 829
                 },
                 "end": {
-                  "line": 103,
-                  "column": 11,
-                  "offset": 9587
+                  "line": 87,
+                  "column": 10,
+                  "offset": 838
                 },
                 "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "\nSample list",
+              "position": {
+                "start": {
+                  "line": 87,
+                  "column": 10,
+                  "offset": 838
+                },
+                "end": {
+                  "line": 88,
+                  "column": 12,
+                  "offset": 850
+                },
+                "indent": [
+                  1
+                ]
               }
             }
           ],
           "position": {
             "start": {
-              "line": 103,
+              "line": 87,
               "column": 1,
-              "offset": 9577
+              "offset": 829
             },
             "end": {
-              "line": 103,
-              "column": 11,
-              "offset": 9587
+              "line": 88,
+              "column": 12,
+              "offset": 850
             },
-            "indent": []
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "linkReference",
+              "identifier": "3: code",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "3: Code",
+                  "position": {
+                    "start": {
+                      "line": 90,
+                      "column": 2,
+                      "offset": 853
+                    },
+                    "end": {
+                      "line": 90,
+                      "column": 9,
+                      "offset": 860
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 90,
+                  "column": 1,
+                  "offset": 852
+                },
+                "end": {
+                  "line": 90,
+                  "column": 10,
+                  "offset": 861
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "\nSample code",
+              "position": {
+                "start": {
+                  "line": 90,
+                  "column": 10,
+                  "offset": 861
+                },
+                "end": {
+                  "line": 91,
+                  "column": 12,
+                  "offset": 873
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 90,
+              "column": 1,
+              "offset": 852
+            },
+            "end": {
+              "line": 91,
+              "column": 12,
+              "offset": 873
+            },
+            "indent": [
+              1
+            ]
           }
         },
         {
@@ -2144,14 +1774,14 @@
           "value": "var x = 10",
           "position": {
             "start": {
-              "line": 104,
+              "line": 92,
               "column": 1,
-              "offset": 9588
+              "offset": 874
             },
             "end": {
-              "line": 106,
+              "line": 94,
               "column": 4,
-              "offset": 9616
+              "offset": 902
             },
             "indent": [
               1,
@@ -2169,9 +1799,9 @@
       "offset": 0
     },
     "end": {
-      "line": 107,
+      "line": 95,
       "column": 1,
-      "offset": 9617
+      "offset": 903
     }
   }
 }

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
@@ -1,0 +1,2177 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "yaml",
+      "value": "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n  - '[Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}'\n\nparent: removing-keys-from-a-binary-search-tree\n",
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 20,
+          "column": 4,
+          "offset": 307
+        },
+        "indent": [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      "data": {
+        "parsedValue": {
+          "author": "jfarmer",
+          "levels": [
+            "beginner",
+            "basic",
+            "medium",
+            "advanced"
+          ],
+          "type": "normal",
+          "category": "must-know",
+          "links": [
+            {
+              "name": "Why is it safer to keep the tree balanced?",
+              "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
+              "nature": "website"
+            }
+          ],
+          "parent": "removing-keys-from-a-binary-search-tree"
+        }
+      }
+    },
+    {
+      "type": "headline",
+      "children": [
+        {
+          "type": "text",
+          "value": "Balanced vs. ",
+          "position": {
+            "start": {
+              "line": 21,
+              "column": 3,
+              "offset": 310
+            },
+            "end": {
+              "line": 21,
+              "column": 16,
+              "offset": 323
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "inlineCode",
+          "value": "Unbalanced",
+          "position": {
+            "start": {
+              "line": 21,
+              "column": 16,
+              "offset": 323
+            },
+            "end": {
+              "line": 21,
+              "column": 28,
+              "offset": 335
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " Binary Trees",
+          "position": {
+            "start": {
+              "line": 21,
+              "column": 28,
+              "offset": 335
+            },
+            "end": {
+              "line": 21,
+              "column": 41,
+              "offset": 348
+            },
+            "indent": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "name": "Content",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "A binary tree is called ",
+              "position": {
+                "start": {
+                  "line": 26,
+                  "column": 1,
+                  "offset": 366
+                },
+                "end": {
+                  "line": 26,
+                  "column": 25,
+                  "offset": 390
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "emphasis",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "balanced",
+                  "position": {
+                    "start": {
+                      "line": 26,
+                      "column": 26,
+                      "offset": 391
+                    },
+                    "end": {
+                      "line": 26,
+                      "column": 34,
+                      "offset": 399
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 26,
+                  "column": 25,
+                  "offset": 390
+                },
+                "end": {
+                  "line": 26,
+                  "column": 35,
+                  "offset": 400
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application.",
+              "position": {
+                "start": {
+                  "line": 26,
+                  "column": 35,
+                  "offset": 400
+                },
+                "end": {
+                  "line": 26,
+                  "column": 441,
+                  "offset": 806
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 1,
+              "offset": 366
+            },
+            "end": {
+              "line": 26,
+              "column": 441,
+              "offset": 806
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree.",
+              "position": {
+                "start": {
+                  "line": 28,
+                  "column": 1,
+                  "offset": 808
+                },
+                "end": {
+                  "line": 28,
+                  "column": 201,
+                  "offset": 1008
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 28,
+              "column": 1,
+              "offset": 808
+            },
+            "end": {
+              "line": 28,
+              "column": 201,
+              "offset": 1008
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:",
+              "position": {
+                "start": {
+                  "line": 30,
+                  "column": 1,
+                  "offset": 1010
+                },
+                "end": {
+                  "line": 30,
+                  "column": 107,
+                  "offset": 1116
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 30,
+              "column": 1,
+              "offset": 1010
+            },
+            "end": {
+              "line": 30,
+              "column": 107,
+              "offset": 1116
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "image",
+              "title": null,
+              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "alt": "unbalanced",
+              "position": {
+                "start": {
+                  "line": 32,
+                  "column": 1,
+                  "offset": 1118
+                },
+                "end": {
+                  "line": 32,
+                  "column": 3539,
+                  "offset": 4656
+                },
+                "indent": []
+              },
+              "svg": true
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 32,
+              "column": 1,
+              "offset": 1118
+            },
+            "end": {
+              "line": 32,
+              "column": 3539,
+              "offset": 4656
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "In order to balance the above tree, the ",
+              "position": {
+                "start": {
+                  "line": 34,
+                  "column": 1,
+                  "offset": 4658
+                },
+                "end": {
+                  "line": 34,
+                  "column": 41,
+                  "offset": 4698
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "inlineCode",
+              "value": "10-15-13",
+              "position": {
+                "start": {
+                  "line": 34,
+                  "column": 41,
+                  "offset": 4698
+                },
+                "end": {
+                  "line": 34,
+                  "column": 51,
+                  "offset": 4708
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " subtree has to be \"rotated\":",
+              "position": {
+                "start": {
+                  "line": 34,
+                  "column": 51,
+                  "offset": 4708
+                },
+                "end": {
+                  "line": 34,
+                  "column": 80,
+                  "offset": 4737
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 34,
+              "column": 1,
+              "offset": 4658
+            },
+            "end": {
+              "line": 34,
+              "column": 80,
+              "offset": 4737
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "image",
+              "title": null,
+              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "alt": "balanced",
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 1,
+                  "offset": 4739
+                },
+                "end": {
+                  "line": 36,
+                  "column": 3537,
+                  "offset": 8275
+                },
+                "indent": []
+              },
+              "svg": true
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 36,
+              "column": 1,
+              "offset": 4739
+            },
+            "end": {
+              "line": 36,
+              "column": 3537,
+              "offset": 8275
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching ",
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 1,
+                  "offset": 8278
+                },
+                "end": {
+                  "line": 39,
+                  "column": 153,
+                  "offset": 8430
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "emphasis",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "on average",
+                  "position": {
+                    "start": {
+                      "line": 39,
+                      "column": 154,
+                      "offset": 8431
+                    },
+                    "end": {
+                      "line": 39,
+                      "column": 164,
+                      "offset": 8441
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 153,
+                  "offset": 8430
+                },
+                "end": {
+                  "line": 39,
+                  "column": 165,
+                  "offset": 8442
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": ", but a linear-time worst case.",
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 165,
+                  "offset": 8442
+                },
+                "end": {
+                  "line": 39,
+                  "column": 196,
+                  "offset": 8473
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 39,
+              "column": 1,
+              "offset": 8278
+            },
+            "end": {
+              "line": 39,
+              "column": 196,
+              "offset": 8473
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees",
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 1,
+                  "offset": 8475
+                },
+                "end": {
+                  "line": 41,
+                  "column": 174,
+                  "offset": 8648
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "linkReference",
+              "identifier": "1",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "1",
+                  "position": {
+                    "start": {
+                      "line": 41,
+                      "column": 175,
+                      "offset": 8649
+                    },
+                    "end": {
+                      "line": 41,
+                      "column": 176,
+                      "offset": 8650
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 174,
+                  "offset": 8648
+                },
+                "end": {
+                  "line": 41,
+                  "column": 177,
+                  "offset": 8651
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " and red-black trees",
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 177,
+                  "offset": 8651
+                },
+                "end": {
+                  "line": 41,
+                  "column": 197,
+                  "offset": 8671
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "linkReference",
+              "identifier": "2",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "2",
+                  "position": {
+                    "start": {
+                      "line": 41,
+                      "column": 198,
+                      "offset": 8672
+                    },
+                    "end": {
+                      "line": 41,
+                      "column": 199,
+                      "offset": 8673
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 197,
+                  "offset": 8671
+                },
+                "end": {
+                  "line": 41,
+                  "column": 200,
+                  "offset": 8674
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": ".",
+              "position": {
+                "start": {
+                  "line": 41,
+                  "column": 200,
+                  "offset": 8674
+                },
+                "end": {
+                  "line": 41,
+                  "column": 201,
+                  "offset": 8675
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 41,
+              "column": 1,
+              "offset": 8475
+            },
+            "end": {
+              "line": 41,
+              "column": 201,
+              "offset": 8675
+            },
+            "indent": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "section",
+      "name": "Practice",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Blah blah blah",
+              "position": {
+                "start": {
+                  "line": 46,
+                  "column": 1,
+                  "offset": 8694
+                },
+                "end": {
+                  "line": 46,
+                  "column": 15,
+                  "offset": 8708
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 46,
+              "column": 1,
+              "offset": 8694
+            },
+            "end": {
+              "line": 46,
+              "column": 15,
+              "offset": 8708
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "questionCode",
+          "lang": "javascript",
+          "value": "Blah blah\n???",
+          "position": {
+            "start": {
+              "line": 48,
+              "column": 1,
+              "offset": 8710
+            },
+            "end": {
+              "line": 51,
+              "column": 4,
+              "offset": 8741
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          },
+          "children": [
+            {
+              "type": "questionCodeLine",
+              "children": [
+                {
+                  "lang": "javascript",
+                  "type": "questionCodeSegment",
+                  "value": "Blah blah"
+                }
+              ]
+            },
+            {
+              "type": "questionCodeLine",
+              "children": [
+                {
+                  "type": "questionGap",
+                  "value": "???"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "loose": false,
+          "children": [
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "abc",
+                      "position": {
+                        "start": {
+                          "line": 53,
+                          "column": 3,
+                          "offset": 8745
+                        },
+                        "end": {
+                          "line": 53,
+                          "column": 6,
+                          "offset": 8748
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 53,
+                      "column": 3,
+                      "offset": 8745
+                    },
+                    "end": {
+                      "line": 53,
+                      "column": 6,
+                      "offset": 8748
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 53,
+                  "column": 1,
+                  "offset": 8743
+                },
+                "end": {
+                  "line": 53,
+                  "column": 6,
+                  "offset": 8748
+                },
+                "indent": []
+              },
+              "correct": true
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "yoli",
+                      "position": {
+                        "start": {
+                          "line": 54,
+                          "column": 3,
+                          "offset": 8751
+                        },
+                        "end": {
+                          "line": 54,
+                          "column": 7,
+                          "offset": 8755
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 54,
+                      "column": 3,
+                      "offset": 8751
+                    },
+                    "end": {
+                      "line": 54,
+                      "column": 7,
+                      "offset": 8755
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 54,
+                  "column": 1,
+                  "offset": 8749
+                },
+                "end": {
+                  "line": 54,
+                  "column": 7,
+                  "offset": 8755
+                },
+                "indent": []
+              },
+              "correct": true
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "yes",
+                      "position": {
+                        "start": {
+                          "line": 55,
+                          "column": 3,
+                          "offset": 8758
+                        },
+                        "end": {
+                          "line": 55,
+                          "column": 6,
+                          "offset": 8761
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 55,
+                      "column": 3,
+                      "offset": 8758
+                    },
+                    "end": {
+                      "line": 55,
+                      "column": 6,
+                      "offset": 8761
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 55,
+                  "column": 1,
+                  "offset": 8756
+                },
+                "end": {
+                  "line": 55,
+                  "column": 6,
+                  "offset": 8761
+                },
+                "indent": []
+              },
+              "correct": false
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 53,
+              "column": 1,
+              "offset": 8743
+            },
+            "end": {
+              "line": 55,
+              "column": 6,
+              "offset": 8761
+            },
+            "indent": [
+              1,
+              1
+            ]
+          },
+          "answers": true
+        }
+      ],
+      "question": true
+    },
+    {
+      "type": "section",
+      "name": "Revision",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Which of the following data structures is a type of ",
+              "position": {
+                "start": {
+                  "line": 60,
+                  "column": 1,
+                  "offset": 8780
+                },
+                "end": {
+                  "line": 60,
+                  "column": 53,
+                  "offset": 8832
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "emphasis",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "maximally-unbalanced",
+                  "position": {
+                    "start": {
+                      "line": 60,
+                      "column": 54,
+                      "offset": 8833
+                    },
+                    "end": {
+                      "line": 60,
+                      "column": 74,
+                      "offset": 8853
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 60,
+                  "column": 53,
+                  "offset": 8832
+                },
+                "end": {
+                  "line": 60,
+                  "column": 75,
+                  "offset": 8854
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " binary tree?",
+              "position": {
+                "start": {
+                  "line": 60,
+                  "column": 75,
+                  "offset": 8854
+                },
+                "end": {
+                  "line": 60,
+                  "column": 88,
+                  "offset": 8867
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 60,
+              "column": 1,
+              "offset": 8780
+            },
+            "end": {
+              "line": 60,
+              "column": 88,
+              "offset": 8867
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "questionGap",
+              "value": "???",
+              "position": {
+                "start": {
+                  "line": 62,
+                  "column": 1,
+                  "offset": 8869
+                },
+                "end": {
+                  "line": 62,
+                  "column": 4,
+                  "offset": 8872
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 62,
+              "column": 1,
+              "offset": 8869
+            },
+            "end": {
+              "line": 62,
+              "column": 4,
+              "offset": 8872
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "loose": false,
+          "children": [
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Ordered linked list",
+                      "position": {
+                        "start": {
+                          "line": 64,
+                          "column": 3,
+                          "offset": 8876
+                        },
+                        "end": {
+                          "line": 64,
+                          "column": 22,
+                          "offset": 8895
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 64,
+                      "column": 3,
+                      "offset": 8876
+                    },
+                    "end": {
+                      "line": 64,
+                      "column": 22,
+                      "offset": 8895
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 64,
+                  "column": 1,
+                  "offset": 8874
+                },
+                "end": {
+                  "line": 64,
+                  "column": 22,
+                  "offset": 8895
+                },
+                "indent": []
+              },
+              "correct": false
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Ordered array",
+                      "position": {
+                        "start": {
+                          "line": 65,
+                          "column": 3,
+                          "offset": 8898
+                        },
+                        "end": {
+                          "line": 65,
+                          "column": 16,
+                          "offset": 8911
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 65,
+                      "column": 3,
+                      "offset": 8898
+                    },
+                    "end": {
+                      "line": 65,
+                      "column": 16,
+                      "offset": 8911
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 65,
+                  "column": 1,
+                  "offset": 8896
+                },
+                "end": {
+                  "line": 65,
+                  "column": 16,
+                  "offset": 8911
+                },
+                "indent": []
+              },
+              "correct": false
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Weighted graph",
+                      "position": {
+                        "start": {
+                          "line": 66,
+                          "column": 3,
+                          "offset": 8914
+                        },
+                        "end": {
+                          "line": 66,
+                          "column": 17,
+                          "offset": 8928
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 66,
+                      "column": 3,
+                      "offset": 8914
+                    },
+                    "end": {
+                      "line": 66,
+                      "column": 17,
+                      "offset": 8928
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 66,
+                  "column": 1,
+                  "offset": 8912
+                },
+                "end": {
+                  "line": 66,
+                  "column": 17,
+                  "offset": 8928
+                },
+                "indent": []
+              },
+              "correct": false
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Max-heap",
+                      "position": {
+                        "start": {
+                          "line": 67,
+                          "column": 3,
+                          "offset": 8931
+                        },
+                        "end": {
+                          "line": 67,
+                          "column": 11,
+                          "offset": 8939
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 67,
+                      "column": 3,
+                      "offset": 8931
+                    },
+                    "end": {
+                      "line": 67,
+                      "column": 11,
+                      "offset": 8939
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 67,
+                  "column": 1,
+                  "offset": 8929
+                },
+                "end": {
+                  "line": 67,
+                  "column": 11,
+                  "offset": 8939
+                },
+                "indent": []
+              },
+              "correct": false
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 64,
+              "column": 1,
+              "offset": 8874
+            },
+            "end": {
+              "line": 67,
+              "column": 11,
+              "offset": 8939
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          },
+          "answers": true
+        }
+      ],
+      "question": true
+    },
+    {
+      "type": "section",
+      "name": "Quiz",
+      "children": [
+        {
+          "type": "questionHeadline",
+          "children": [
+            {
+              "type": "text",
+              "value": "what is the output of ",
+              "position": {
+                "start": {
+                  "line": 72,
+                  "column": 5,
+                  "offset": 8958
+                },
+                "end": {
+                  "line": 72,
+                  "column": 27,
+                  "offset": 8980
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "inlineCode",
+              "value": "the",
+              "position": {
+                "start": {
+                  "line": 72,
+                  "column": 27,
+                  "offset": 8980
+                },
+                "end": {
+                  "line": 72,
+                  "column": 32,
+                  "offset": 8985
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": " following script?",
+              "position": {
+                "start": {
+                  "line": 72,
+                  "column": 32,
+                  "offset": 8985
+                },
+                "end": {
+                  "line": 72,
+                  "column": 50,
+                  "offset": 9003
+                },
+                "indent": []
+              }
+            }
+          ]
+        },
+        {
+          "type": "code",
+          "lang": "bash",
+          "value": "#!/bin/bash\na=1\n{ a=2 }\necho $a",
+          "position": {
+            "start": {
+              "line": 74,
+              "column": 1,
+              "offset": 9005
+            },
+            "end": {
+              "line": 79,
+              "column": 4,
+              "offset": 9048
+            },
+            "indent": [
+              1,
+              1,
+              1,
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "There is a list here:",
+              "position": {
+                "start": {
+                  "line": 81,
+                  "column": 1,
+                  "offset": 9050
+                },
+                "end": {
+                  "line": 81,
+                  "column": 22,
+                  "offset": 9071
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 81,
+              "column": 1,
+              "offset": 9050
+            },
+            "end": {
+              "line": 81,
+              "column": 22,
+              "offset": 9071
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "loose": false,
+          "children": [
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "abc",
+                      "position": {
+                        "start": {
+                          "line": 82,
+                          "column": 3,
+                          "offset": 9074
+                        },
+                        "end": {
+                          "line": 82,
+                          "column": 6,
+                          "offset": 9077
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 3,
+                      "offset": 9074
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 6,
+                      "offset": 9077
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 82,
+                  "column": 1,
+                  "offset": 9072
+                },
+                "end": {
+                  "line": 82,
+                  "column": 6,
+                  "offset": 9077
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "def",
+                      "position": {
+                        "start": {
+                          "line": 83,
+                          "column": 3,
+                          "offset": 9080
+                        },
+                        "end": {
+                          "line": 83,
+                          "column": 6,
+                          "offset": 9083
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 83,
+                      "column": 3,
+                      "offset": 9080
+                    },
+                    "end": {
+                      "line": 83,
+                      "column": 6,
+                      "offset": 9083
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 83,
+                  "column": 1,
+                  "offset": 9078
+                },
+                "end": {
+                  "line": 83,
+                  "column": 6,
+                  "offset": 9083
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "abcd",
+                      "position": {
+                        "start": {
+                          "line": 84,
+                          "column": 3,
+                          "offset": 9086
+                        },
+                        "end": {
+                          "line": 84,
+                          "column": 7,
+                          "offset": 9090
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 84,
+                      "column": 3,
+                      "offset": 9086
+                    },
+                    "end": {
+                      "line": 84,
+                      "column": 7,
+                      "offset": 9090
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 84,
+                  "column": 1,
+                  "offset": 9084
+                },
+                "end": {
+                  "line": 84,
+                  "column": 7,
+                  "offset": 9090
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 82,
+              "column": 1,
+              "offset": 9072
+            },
+            "end": {
+              "line": 84,
+              "column": 7,
+              "offset": 9090
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "loose": false,
+          "children": [
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "\"Error: unexpected end of file\"",
+                      "position": {
+                        "start": {
+                          "line": 86,
+                          "column": 3,
+                          "offset": 9094
+                        },
+                        "end": {
+                          "line": 86,
+                          "column": 34,
+                          "offset": 9125
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 86,
+                      "column": 3,
+                      "offset": 9094
+                    },
+                    "end": {
+                      "line": 86,
+                      "column": 34,
+                      "offset": 9125
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 86,
+                  "column": 1,
+                  "offset": 9092
+                },
+                "end": {
+                  "line": 86,
+                  "column": 34,
+                  "offset": 9125
+                },
+                "indent": []
+              },
+              "correct": false
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "1",
+                      "position": {
+                        "start": {
+                          "line": 87,
+                          "column": 3,
+                          "offset": 9128
+                        },
+                        "end": {
+                          "line": 87,
+                          "column": 6,
+                          "offset": 9131
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 87,
+                      "column": 3,
+                      "offset": 9128
+                    },
+                    "end": {
+                      "line": 87,
+                      "column": 6,
+                      "offset": 9131
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 87,
+                  "column": 1,
+                  "offset": 9126
+                },
+                "end": {
+                  "line": 87,
+                  "column": 6,
+                  "offset": 9131
+                },
+                "indent": []
+              },
+              "correct": false
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "2",
+                      "position": {
+                        "start": {
+                          "line": 88,
+                          "column": 3,
+                          "offset": 9134
+                        },
+                        "end": {
+                          "line": 88,
+                          "column": 4,
+                          "offset": 9135
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 88,
+                      "column": 3,
+                      "offset": 9134
+                    },
+                    "end": {
+                      "line": 88,
+                      "column": 4,
+                      "offset": 9135
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 88,
+                  "column": 1,
+                  "offset": 9132
+                },
+                "end": {
+                  "line": 88,
+                  "column": 4,
+                  "offset": 9135
+                },
+                "indent": []
+              },
+              "correct": false
+            },
+            {
+              "type": "listItem",
+              "loose": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "$a",
+                      "position": {
+                        "start": {
+                          "line": 89,
+                          "column": 3,
+                          "offset": 9138
+                        },
+                        "end": {
+                          "line": 89,
+                          "column": 5,
+                          "offset": 9140
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 89,
+                      "column": 3,
+                      "offset": 9138
+                    },
+                    "end": {
+                      "line": 89,
+                      "column": 5,
+                      "offset": 9140
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 89,
+                  "column": 1,
+                  "offset": 9136
+                },
+                "end": {
+                  "line": 89,
+                  "column": 5,
+                  "offset": 9140
+                },
+                "indent": []
+              },
+              "correct": false
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 86,
+              "column": 1,
+              "offset": 9092
+            },
+            "end": {
+              "line": 89,
+              "column": 5,
+              "offset": 9140
+            },
+            "indent": [
+              1,
+              1,
+              1
+            ]
+          },
+          "answers": true
+        }
+      ],
+      "question": true
+    },
+    {
+      "type": "section",
+      "name": "Footnotes",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "linkReference",
+              "identifier": "1: avl tree",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "1: AVL tree",
+                  "position": {
+                    "start": {
+                      "line": 94,
+                      "column": 2,
+                      "offset": 9161
+                    },
+                    "end": {
+                      "line": 94,
+                      "column": 13,
+                      "offset": 9172
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 94,
+                  "column": 1,
+                  "offset": 9160
+                },
+                "end": {
+                  "line": 94,
+                  "column": 14,
+                  "offset": 9173
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.",
+              "position": {
+                "start": {
+                  "line": 94,
+                  "column": 14,
+                  "offset": 9173
+                },
+                "end": {
+                  "line": 95,
+                  "column": 116,
+                  "offset": 9289
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 94,
+              "column": 1,
+              "offset": 9160
+            },
+            "end": {
+              "line": 95,
+              "column": 116,
+              "offset": 9289
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "linkReference",
+              "identifier": "2: red-black tree",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "2: Red-Black tree",
+                  "position": {
+                    "start": {
+                      "line": 97,
+                      "column": 2,
+                      "offset": 9292
+                    },
+                    "end": {
+                      "line": 97,
+                      "column": 19,
+                      "offset": 9309
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 97,
+                  "column": 1,
+                  "offset": 9291
+                },
+                "end": {
+                  "line": 97,
+                  "column": 20,
+                  "offset": 9310
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.",
+              "position": {
+                "start": {
+                  "line": 97,
+                  "column": 20,
+                  "offset": 9310
+                },
+                "end": {
+                  "line": 98,
+                  "column": 222,
+                  "offset": 9532
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 97,
+              "column": 1,
+              "offset": 9291
+            },
+            "end": {
+              "line": 98,
+              "column": 222,
+              "offset": 9532
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "linkReference",
+              "identifier": "3: blah blah",
+              "referenceType": "shortcut",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "3: Blah blah",
+                  "position": {
+                    "start": {
+                      "line": 100,
+                      "column": 2,
+                      "offset": 9535
+                    },
+                    "end": {
+                      "line": 100,
+                      "column": 14,
+                      "offset": 9547
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 100,
+                  "column": 1,
+                  "offset": 9534
+                },
+                "end": {
+                  "line": 100,
+                  "column": 15,
+                  "offset": 9548
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "\nThis is the third footnote",
+              "position": {
+                "start": {
+                  "line": 100,
+                  "column": 15,
+                  "offset": 9548
+                },
+                "end": {
+                  "line": 101,
+                  "column": 27,
+                  "offset": 9575
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 100,
+              "column": 1,
+              "offset": 9534
+            },
+            "end": {
+              "line": 101,
+              "column": 27,
+              "offset": 9575
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "with code:",
+              "position": {
+                "start": {
+                  "line": 103,
+                  "column": 1,
+                  "offset": 9577
+                },
+                "end": {
+                  "line": 103,
+                  "column": 11,
+                  "offset": 9587
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 103,
+              "column": 1,
+              "offset": 9577
+            },
+            "end": {
+              "line": 103,
+              "column": 11,
+              "offset": 9587
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "code",
+          "lang": "javascript",
+          "value": "var x = 10",
+          "position": {
+            "start": {
+              "line": 104,
+              "column": 1,
+              "offset": 9588
+            },
+            "end": {
+              "line": 106,
+              "column": 4,
+              "offset": 9616
+            },
+            "indent": [
+              1,
+              1
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 107,
+      "column": 1,
+      "offset": 9617
+    }
+  }
+}

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
@@ -1,0 +1,73 @@
+{
+  "metadata": {
+    "author": "jfarmer",
+    "levels": [
+      "beginner",
+      "basic",
+      "medium",
+      "advanced"
+    ],
+    "type": "normal",
+    "category": "must-know",
+    "links": [
+      {
+        "name": "Why is it safer to keep the tree balanced?",
+        "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
+        "nature": "website"
+      }
+    ],
+    "parent": "removing-keys-from-a-binary-search-tree"
+  },
+  "headline": "Balanced vs. `Unbalanced` Binary Trees",
+  "content": "A binary tree is called *balanced* if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application.\n\nThis distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree.\n\nConsider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:\n\n![unbalanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)\n\nIn order to balance the above tree, the `10-15-13` subtree has to be \"rotated\":\n\n![balanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)\n\nThis is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching *on average*, but a linear-time worst case.\n\nSolving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees[1] and red-black trees[2].\n",
+  "practice": {
+    "rawText": "Blah blah blah\n\n```javascript\nBlah blah\n???\n```\n\n* abc\n* yoli\n* yes\n",
+    "question": "Blah blah blah\n\n```javascript\nBlah blah\n???\n```\n",
+    "answers": [
+      "abc",
+      "yoli",
+      "yes"
+    ]
+  },
+  "revision": {
+    "rawText": "Which of the following data structures is a type of *maximally-unbalanced* binary tree?\n\n???\n\n* Ordered linked list\n* Ordered array\n* Weighted graph\n* Max-heap\n",
+    "question": "Which of the following data structures is a type of *maximally-unbalanced* binary tree?\n\n???\n",
+    "answers": [
+      "Ordered linked list",
+      "Ordered array",
+      "Weighted graph",
+      "Max-heap"
+    ]
+  },
+  "quiz": {
+    "rawText": "### what is the output of \n\n`the`\n\n following script?\n\n\n```bash\n#!/bin/bash\na=1\n{ a=2 }\necho $a\n```\n\nThere is a list here:\n\n* abc\n* def\n* abcd\n\n\n* \"Error: unexpected end of file\"\n* `1`\n* 2\n* $a\n",
+    "headline": "what is the output of `the` following script?",
+    "question": "```bash\n#!/bin/bash\na=1\n{ a=2 }\necho $a\n```\n\nThere is a list here:\n\n* abc\n* def\n* abcd\n",
+    "answers": [
+      "\"Error: unexpected end of file\"",
+      "`1`",
+      "2",
+      "$a"
+    ]
+  },
+  "footnotes": {
+    "rawText": "[1: AVL tree]\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.\n\n[2: Red-Black tree]\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.\n\n[3: Blah blah]\nThis is the third footnote\n\nwith code:\n\n```javascript\nvar x = 10\n```\n",
+    "items": [
+      {
+        "number": "1",
+        "name": " AVL tree",
+        "text": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.\n\n"
+      },
+      {
+        "number": "2",
+        "name": " Red-Black tree",
+        "text": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.\n\n"
+      },
+      {
+        "number": "3",
+        "name": " Blah blah",
+        "text": "\nThis is the third footnote\n\nwith code:\n\n```javascript\nvar x = 10\n```\n"
+      }
+    ]
+  }
+}

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
@@ -1,72 +1,123 @@
 {
   "metadata": {
-    "author": "jfarmer",
+    "author": "catalin",
     "levels": [
-      "beginner",
       "basic",
       "medium",
       "advanced"
     ],
     "type": "normal",
     "category": "must-know",
+    "standards": {
+      "sql.use-dql.0": 10,
+      "sql.use-ddl.1": 1000
+    },
+    "tags": [
+      "introduction",
+      "workout"
+    ],
+    "stub": false,
     "links": [
       {
-        "name": "Why is it safer to keep the tree balanced?",
-        "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
+        "name": "EnkiCool",
+        "url": "https://enki.com",
         "nature": "website"
       }
-    ],
-    "parent": "removing-keys-from-a-binary-search-tree"
+    ]
   },
-  "headline": "Balanced vs. `Unbalanced` Binary Trees",
-  "content": "A binary tree is called *balanced* if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application.\n\nThis distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree.\n\nConsider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:\n\n![unbalanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)\n\nIn order to balance the above tree, the `10-15-13` subtree has to be \"rotated\":\n\n![balanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)\n\nThis is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching *on average*, but a linear-time worst case.\n\nSolving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees[1] and red-black trees[2].\n",
+  "headline": "Sample title with `code` within",
+  "content": "This is a sample paragraph.[1]\n\nThis is a sample list[2]&#x3A;\n\n* item one\n* item `two`\n\nSample code[3]&#x3A;\n\n```javascript\nconsole.log('sample code')\n```\n",
   "practice": {
-    "rawText": "Blah blah blah\n\n```javascript\nBlah blah\n???\n```\n\n* abc\n* yoli\n* yes\n",
-    "question": "Blah blah blah\n\n```javascript\nBlah blah\n???\n```\n",
+    "rawText": "This is a sample question with one gap:\n\n???\n\n* correct\n* incorrect\n* not a chance\n",
+    "question": "This is a sample question with one gap:\n\n???\n",
     "answers": [
-      "abc",
-      "yoli",
-      "yes"
+      {
+        "text": "correct",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "incorrect",
+        "correct": true,
+        "correctIndex": 1
+      },
+      {
+        "text": "not a chance",
+        "correct": true,
+        "correctIndex": 2
+      }
     ]
   },
   "revision": {
-    "rawText": "Which of the following data structures is a type of *maximally-unbalanced* binary tree?\n\n???\n\n* Ordered linked list\n* Ordered array\n* Weighted graph\n* Max-heap\n",
-    "question": "Which of the following data structures is a type of *maximally-unbalanced* binary tree?\n\n???\n",
+    "rawText": "This is a sample question with two gaps:\n\n???\n\n???\n\n* correct\n* also correct\n* nah bro\n* fam, just no\n",
+    "question": "This is a sample question with two gaps:\n\n???\n\n???\n",
     "answers": [
-      "Ordered linked list",
-      "Ordered array",
-      "Weighted graph",
-      "Max-heap"
+      {
+        "text": "correct",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "also correct",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "nah bro",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "fam, just no",
+        "correct": false,
+        "correctIndex": null
+      }
     ]
   },
   "quiz": {
-    "rawText": "### what is the output of \n\n`the`\n\n following script?\n\n\n```bash\n#!/bin/bash\na=1\n{ a=2 }\necho $a\n```\n\nThere is a list here:\n\n* abc\n* def\n* abcd\n\n\n* \"Error: unexpected end of file\"\n* `1`\n* 2\n* $a\n",
-    "headline": "what is the output of `the` following script?",
-    "question": "```bash\n#!/bin/bash\na=1\n{ a=2 }\necho $a\n```\n\nThere is a list here:\n\n* abc\n* def\n* abcd\n",
+    "rawText": "### Quiz title\n\n\nSample quiz question\n\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
+    "headline": "Quiz title",
+    "question": "Sample quiz question\n",
     "answers": [
-      "\"Error: unexpected end of file\"",
-      "`1`",
-      "2",
-      "$a"
+      {
+        "text": "correct",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "*incorrect*",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "not a `chance`",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "nope",
+        "correct": false,
+        "correctIndex": null
+      }
     ]
   },
   "footnotes": {
-    "rawText": "[1: AVL tree]\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.\n\n[2: Red-Black tree]\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.\n\n[3: Blah blah]\nThis is the third footnote\n\nwith code:\n\n```javascript\nvar x = 10\n```\n",
+    "rawText": "[1: Paragraph]\nSample explanation\n\n[2: List]\nSample list\n\n[3: Code]\nSample code\n\n```javascript\nvar x = 10\n```\n",
     "items": [
       {
         "number": "1",
-        "name": " AVL tree",
-        "text": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.\n\n"
+        "name": " Paragraph",
+        "text": "\nSample explanation\n\n"
       },
       {
         "number": "2",
-        "name": " Red-Black tree",
-        "text": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.\n\n"
+        "name": " List",
+        "text": "\nSample list\n\n"
       },
       {
         "number": "3",
-        "name": " Blah blah",
-        "text": "\nThis is the third footnote\n\nwith code:\n\n```javascript\nvar x = 10\n```\n"
+        "name": " Code",
+        "text": "\nSample code\n\n```javascript\nvar x = 10\n```\n"
       }
     ]
   }

--- a/packages/curriculum-compiler-json/__tests__/insight/compile-sync.test.js
+++ b/packages/curriculum-compiler-json/__tests__/insight/compile-sync.test.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const jestInCase = require('jest-in-case')
+const jsonfile = require('jsonfile')
+const { contentTypes } = require('@enkidevs/curriculum-helpers')
+const { getCompiler } = require('../../index')
+
+const fixturePath = (dir, name) =>
+  path.join(__dirname, '../', 'fixtures', 'insight', dir, name)
+
+jestInCase(
+  'Insight AST to JSON Compilation (Sync)',
+  fixture => {
+    const compiler = getCompiler(contentTypes.INSIGHT)
+    const json = compiler.compileSync(fixture.ast)
+    expect(json).toEqual(fixture.parsed)
+  },
+  ['sample', 'exercise'].map(dir => ({
+    parsed: jsonfile.readFileSync(fixturePath(dir, 'parsed.json')),
+    ast: jsonfile.readFileSync(fixturePath(dir, 'ast.json'))
+  }))
+)

--- a/packages/curriculum-compiler-json/compilers/footnotes.js
+++ b/packages/curriculum-compiler-json/compilers/footnotes.js
@@ -1,0 +1,35 @@
+const { compileNodeToInsightMarkdown } = require('./helpers')
+
+module.exports = function footnotes (node) {
+  const rawText = compileNodeToInsightMarkdown(node)
+  const items = parseRawFootnotes(rawText)
+  return {
+    footnotes: {
+      rawText,
+      items
+    }
+  }
+}
+
+function parseRawFootnotes (text) {
+  const splitTextArray = text.split(/(\[.*:.*\])/gi).filter(Boolean)
+  return splitTextArray.reduce((items, line, index, array) => {
+    if (index % 2 === 1) {
+      return items
+    }
+    const footnoteHeadlineRegExp = /[[0-9]:.*\]/i
+    const nextLine = array[index + 1]
+    if (
+      !line.match(footnoteHeadlineRegExp) ||
+      nextLine.match(footnoteHeadlineRegExp)
+    ) {
+      throw new Error('Cannot parse invalid footnotes')
+    }
+    const [number, name] = line.substring(1, line.length - 1).split(':')
+    return items.concat({
+      number,
+      name,
+      text: nextLine
+    })
+  }, [])
+}

--- a/packages/curriculum-compiler-json/compilers/headline.js
+++ b/packages/curriculum-compiler-json/compilers/headline.js
@@ -1,0 +1,7 @@
+const { compileNodeToInsightMarkdown } = require('./helpers')
+
+module.exports = function (node) {
+  return {
+    headline: compileNodeToInsightMarkdown(node).split('\n').join('')
+  }
+}

--- a/packages/curriculum-compiler-json/compilers/helpers.js
+++ b/packages/curriculum-compiler-json/compilers/helpers.js
@@ -1,3 +1,4 @@
+const unistBuilder = require('unist-builder')
 const { getCompiler } = require('@enkidevs/curriculum-compiler-string')
 const { contentTypes } = require('@enkidevs/curriculum-helpers')
 
@@ -8,10 +9,7 @@ function compileNodeToInsightMarkdown (node) {
   if (!node || !node.children) {
     throw new Error('Cannot compile invalid node')
   }
-  return getInsightCompiler().compileSync({
-    type: 'root',
-    children: node.children
-  })
+  return getInsightCompiler().compileSync(unistBuilder('root', node.children))
 }
 
 function getAnswersFromNode (node) {

--- a/packages/curriculum-compiler-json/compilers/helpers.js
+++ b/packages/curriculum-compiler-json/compilers/helpers.js
@@ -18,13 +18,16 @@ function getAnswersFromNode (node) {
   const answersASTList = node.children.find(
     child => child.type === 'list' && child.answers
   )
-  if (!answersASTList) {
-    throw new Error('No answers in question node')
+  if (!answersASTList || !answersASTList.children) {
+    throw new Error('No valid answer list in question node')
   }
-  return compileNodeToInsightMarkdown({ children: [answersASTList] })
-    .split('\n')
-    .filter(Boolean)
-    .map(i => i.substring(1).trim())
+
+  let tempCorrectIndex = 0
+  return answersASTList.children.map(answerNode => ({
+    text: compileNodeToInsightMarkdown(answerNode).replace('\n', ''),
+    correct: answerNode.correct,
+    correctIndex: answerNode.correct ? tempCorrectIndex++ : null
+  }))
 }
 
 module.exports = {

--- a/packages/curriculum-compiler-json/compilers/helpers.js
+++ b/packages/curriculum-compiler-json/compilers/helpers.js
@@ -1,0 +1,33 @@
+const { getCompiler } = require('@enkidevs/curriculum-compiler-string')
+const { contentTypes } = require('@enkidevs/curriculum-helpers')
+
+function getInsightCompiler () {
+  return getCompiler(contentTypes.INSIGHT)
+}
+function compileNodeToInsightMarkdown (node) {
+  if (!node || !node.children) {
+    throw new Error('Cannot compile invalid node')
+  }
+  return getInsightCompiler().compileSync({
+    type: 'root',
+    children: node.children
+  })
+}
+
+function getAnswersFromNode (node) {
+  const answersASTList = node.children.find(
+    child => child.type === 'list' && child.answers
+  )
+  if (!answersASTList) {
+    throw new Error('No answers in question node')
+  }
+  return compileNodeToInsightMarkdown({ children: [answersASTList] })
+    .split('\n')
+    .filter(Boolean)
+    .map(i => i.substring(1).trim())
+}
+
+module.exports = {
+  compileNodeToInsightMarkdown,
+  getAnswersFromNode
+}

--- a/packages/curriculum-compiler-json/compilers/index.js
+++ b/packages/curriculum-compiler-json/compilers/index.js
@@ -1,0 +1,15 @@
+const metadata = require('./metadata')
+const headline = require('./headline')
+const quiz = require('./quiz')
+const question = require('./question')
+const footnotes = require('./footnotes')
+const helpers = require('./helpers')
+
+module.exports = {
+  metadata,
+  headline,
+  quiz,
+  question,
+  footnotes,
+  helpers
+}

--- a/packages/curriculum-compiler-json/compilers/metadata.js
+++ b/packages/curriculum-compiler-json/compilers/metadata.js
@@ -1,0 +1,8 @@
+module.exports = function metadata (node) {
+  if (!node.data || !node.data.parsedValue) {
+    throw new Error('Invalid YAML node')
+  }
+  return {
+    metadata: node.data.parsedValue
+  }
+}

--- a/packages/curriculum-compiler-json/compilers/question.js
+++ b/packages/curriculum-compiler-json/compilers/question.js
@@ -1,0 +1,25 @@
+const {
+  compileNodeToInsightMarkdown,
+  getAnswersFromNode
+} = require('./helpers')
+
+module.exports = function question (node, type) {
+  if (!node.question) {
+    throw new Error(`Invalid question section ${node.name}`)
+  }
+  const rawText = compileNodeToInsightMarkdown(node)
+  const answers = getAnswersFromNode(node)
+  const question = compileNodeToInsightMarkdown({
+    children: node.children.filter(
+      child => child.type !== 'list' && !child.answers
+    )
+  })
+
+  return {
+    [type]: {
+      rawText,
+      question,
+      answers
+    }
+  }
+}

--- a/packages/curriculum-compiler-json/compilers/quiz.js
+++ b/packages/curriculum-compiler-json/compilers/quiz.js
@@ -1,0 +1,29 @@
+const {
+  compileNodeToInsightMarkdown,
+  getAnswersFromNode
+} = require('./helpers')
+
+module.exports = function quiz (node) {
+  const rawText = compileNodeToInsightMarkdown(node)
+  const headline = compileNodeToInsightMarkdown(
+    node.children.find(child => child.type === 'questionHeadline')
+  )
+    .split('\n')
+    .join('')
+  const answers = getAnswersFromNode(node)
+
+  const question = compileNodeToInsightMarkdown({
+    children: node.children.filter(
+      child => child.type !== 'questionHeadline' && !child.answers
+    )
+  })
+
+  return {
+    quiz: {
+      rawText,
+      headline,
+      question,
+      answers
+    }
+  }
+}

--- a/packages/curriculum-compiler-json/index.js
+++ b/packages/curriculum-compiler-json/index.js
@@ -53,10 +53,7 @@ function getCompiler (type) {
       throw new Error('Missing or invalid AST')
     }
     const json = ast.children.reduce((tempJson, node) => {
-      return {
-        ...tempJson,
-        ...compileSection(node)
-      }
+      return Object.assign({}, tempJson, compileSection(node))
     }, {})
     return json
   }

--- a/packages/curriculum-compiler-json/index.js
+++ b/packages/curriculum-compiler-json/index.js
@@ -1,0 +1,71 @@
+const { sectionNames, questionTypes } = require('@enkidevs/curriculum-helpers')
+const compilers = require('./compilers')
+
+const { compileNodeToInsightMarkdown } = compilers.helpers
+
+const nodeTypeMap = {
+  yaml: node => compilers.metadata(node),
+  headline: node => compilers.headline(node),
+  section: node => {
+    if (!node.name) {
+      throw new Error(`Invalid section node with no name`)
+    }
+    const compiler = nodeSectionMap[node.name]
+    if (!compiler) {
+      throw new Error(`Cannot compile section node with name ${node.name}`)
+    }
+    return compiler(node)
+  }
+}
+
+const nodeSectionMap = {
+  [sectionNames.CONTENT]: node => ({
+    content: compileNodeToInsightMarkdown(node)
+  }),
+  [sectionNames.GAME_CONTENT]: node => ({
+    gameContent: compileNodeToInsightMarkdown(node)
+  }),
+  [sectionNames.EXERCISE]: node => ({
+    exercise: compileNodeToInsightMarkdown(node)
+  }),
+  [sectionNames.PRACTICE]: node =>
+    compilers.question(node, questionTypes.PRACTICE),
+  [sectionNames.REVISION]: node =>
+    compilers.question(node, questionTypes.REVISION),
+  [sectionNames.QUIZ]: node => compilers.quiz(node),
+  [sectionNames.FOOTNOTES]: node => compilers.footnotes(node)
+}
+
+function compileSection (node) {
+  if (!node || !node.type) {
+    throw new Error('Invalid node with no type')
+  }
+  const compiler = nodeTypeMap[node.type]
+  if (!compiler) {
+    throw new Error(`Cannot compile node with invalid type ${node.type}`)
+  }
+  return compiler(node)
+}
+
+function getCompiler (type) {
+  function compileSync (ast) {
+    if (!ast || !ast.children) {
+      throw new Error('Missing or invalid AST')
+    }
+    const json = ast.children.reduce((tempJson, node) => {
+      return {
+        ...tempJson,
+        ...compileSection(node)
+      }
+    }, {})
+    return json
+  }
+
+  return {
+    compileSync
+  }
+}
+
+module.exports = {
+  getCompiler
+}

--- a/packages/curriculum-compiler-json/index.sandbox.js
+++ b/packages/curriculum-compiler-json/index.sandbox.js
@@ -1,6 +1,4 @@
 // Use this sandbox to play with the parser
-const parser = require('../../packages/curriculum-parser/index')
-
 const ast = {
   type: 'root',
   children: [

--- a/packages/curriculum-compiler-json/index.sandbox.js
+++ b/packages/curriculum-compiler-json/index.sandbox.js
@@ -1,114 +1,1775 @@
 // Use this sandbox to play with the parser
 const parser = require('../../packages/curriculum-parser/index')
 
-const ast = parser.getParser('insight')
-  .parseSync(`---
-author: jfarmer
-
-levels:
-
-  - beginner
-  - basic
-  - medium
-  - advanced
-
-type: normal
-
-category: must-know
-
-links:
-  - '[Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}'
-
-parent: removing-keys-from-a-binary-search-tree
-
----
-# Balanced vs. \`Unbalanced\` Binary Trees
-
----
-## Content
-
-A binary tree is called *balanced* if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases "approximately the same" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application.
-
-This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree.
-
-Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:
-
-![unbalanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)
-
-In order to balance the above tree, the \`10-15-13\` subtree has to be "rotated":
-
-![balanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)
-
-
-This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching *on average*, but a linear-time worst case.
-
-Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees[1] and red-black trees[2].
-
----
-## Practice
-
-Blah blah blah
-
-\`\`\`javascript
-Blah blah
-???
-\`\`\`
-
-* abc
-* yoli
-* yes
-
----
-## Revision
-
-Which of the following data structures is a type of *maximally-unbalanced* binary tree?
-
-???
-
-* Ordered linked list
-* Ordered array
-* Weighted graph
-* Max-heap
-
----
-## Quiz
-
-### what is the output of \`the\` following script?
-
-\`\`\`bash
-#!/bin/bash
-a=1
-{ a=2 }
-echo $a
-\`\`\`
-
-There is a list here:
-- abc
-- def
-- abcd
-
-* "Error: unexpected end of file"
-* \`1\`
-* 2
-* $a
-
----
-## Footnotes
-
-[1: AVL tree]
-Self-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.
-
-[2: Red-Black tree]
-Self-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.
-
-[3: Blah blah]
-This is the third footnote
-
-with code:
-\`\`\`javascript
-var x = 10
-\`\`\`
-`)
+const ast = {
+  type: 'root',
+  children: [
+    {
+      type: 'yaml',
+      value: "author: catalin\n\nlevels:\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\n\ntags:\n  - introduction\n  - workout\n\nstub: false\n\nlinks:\n  - '[EnkiCool](https://enki.com){website}'\n",
+      position: {
+        start: {
+          line: 1,
+          column: 1,
+          offset: 0
+        },
+        end: {
+          line: 26,
+          column: 4,
+          offset: 257
+        },
+        indent: [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      },
+      data: {
+        parsedValue: {
+          author: 'catalin',
+          levels: ['basic', 'medium', 'advanced'],
+          type: 'normal',
+          category: 'must-know',
+          standards: {
+            'sql.use-dql.0': 10,
+            'sql.use-ddl.1': 1000
+          },
+          tags: ['introduction', 'workout'],
+          stub: false,
+          links: [
+            {
+              name: 'EnkiCool',
+              url: 'https://enki.com',
+              nature: 'website'
+            }
+          ]
+        }
+      }
+    },
+    {
+      type: 'headline',
+      children: [
+        {
+          type: 'text',
+          value: 'Sample title with ',
+          position: {
+            start: {
+              line: 27,
+              column: 3,
+              offset: 260
+            },
+            end: {
+              line: 27,
+              column: 21,
+              offset: 278
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'inlineCode',
+          value: 'code',
+          position: {
+            start: {
+              line: 27,
+              column: 21,
+              offset: 278
+            },
+            end: {
+              line: 27,
+              column: 27,
+              offset: 284
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'text',
+          value: ' within',
+          position: {
+            start: {
+              line: 27,
+              column: 27,
+              offset: 284
+            },
+            end: {
+              line: 27,
+              column: 34,
+              offset: 291
+            },
+            indent: []
+          }
+        }
+      ]
+    },
+    {
+      type: 'section',
+      name: 'Content',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'This is a sample paragraph.',
+              position: {
+                start: {
+                  line: 32,
+                  column: 1,
+                  offset: 309
+                },
+                end: {
+                  line: 32,
+                  column: 28,
+                  offset: 336
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'linkReference',
+              identifier: '1',
+              referenceType: 'shortcut',
+              children: [
+                {
+                  type: 'text',
+                  value: '1',
+                  position: {
+                    start: {
+                      line: 32,
+                      column: 29,
+                      offset: 337
+                    },
+                    end: {
+                      line: 32,
+                      column: 30,
+                      offset: 338
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 32,
+                  column: 28,
+                  offset: 336
+                },
+                end: {
+                  line: 32,
+                  column: 31,
+                  offset: 339
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 32,
+              column: 1,
+              offset: 309
+            },
+            end: {
+              line: 32,
+              column: 31,
+              offset: 339
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'This is a sample list',
+              position: {
+                start: {
+                  line: 34,
+                  column: 1,
+                  offset: 341
+                },
+                end: {
+                  line: 34,
+                  column: 22,
+                  offset: 362
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'linkReference',
+              identifier: '2',
+              referenceType: 'shortcut',
+              children: [
+                {
+                  type: 'text',
+                  value: '2',
+                  position: {
+                    start: {
+                      line: 34,
+                      column: 23,
+                      offset: 363
+                    },
+                    end: {
+                      line: 34,
+                      column: 24,
+                      offset: 364
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 34,
+                  column: 22,
+                  offset: 362
+                },
+                end: {
+                  line: 34,
+                  column: 25,
+                  offset: 365
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'text',
+              value: ':',
+              position: {
+                start: {
+                  line: 34,
+                  column: 25,
+                  offset: 365
+                },
+                end: {
+                  line: 34,
+                  column: 26,
+                  offset: 366
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 34,
+              column: 1,
+              offset: 341
+            },
+            end: {
+              line: 34,
+              column: 26,
+              offset: 366
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'list',
+          ordered: false,
+          start: null,
+          loose: false,
+          children: [
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'item one',
+                      position: {
+                        start: {
+                          line: 36,
+                          column: 3,
+                          offset: 370
+                        },
+                        end: {
+                          line: 36,
+                          column: 11,
+                          offset: 378
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 36,
+                      column: 3,
+                      offset: 370
+                    },
+                    end: {
+                      line: 36,
+                      column: 11,
+                      offset: 378
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 36,
+                  column: 1,
+                  offset: 368
+                },
+                end: {
+                  line: 36,
+                  column: 11,
+                  offset: 378
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'item ',
+                      position: {
+                        start: {
+                          line: 37,
+                          column: 3,
+                          offset: 381
+                        },
+                        end: {
+                          line: 37,
+                          column: 8,
+                          offset: 386
+                        },
+                        indent: []
+                      }
+                    },
+                    {
+                      type: 'inlineCode',
+                      value: 'two',
+                      position: {
+                        start: {
+                          line: 37,
+                          column: 8,
+                          offset: 386
+                        },
+                        end: {
+                          line: 37,
+                          column: 13,
+                          offset: 391
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 37,
+                      column: 3,
+                      offset: 381
+                    },
+                    end: {
+                      line: 37,
+                      column: 13,
+                      offset: 391
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 37,
+                  column: 1,
+                  offset: 379
+                },
+                end: {
+                  line: 37,
+                  column: 13,
+                  offset: 391
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 36,
+              column: 1,
+              offset: 368
+            },
+            end: {
+              line: 37,
+              column: 13,
+              offset: 391
+            },
+            indent: [1]
+          }
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'Sample code',
+              position: {
+                start: {
+                  line: 39,
+                  column: 1,
+                  offset: 393
+                },
+                end: {
+                  line: 39,
+                  column: 12,
+                  offset: 404
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'linkReference',
+              identifier: '3',
+              referenceType: 'shortcut',
+              children: [
+                {
+                  type: 'text',
+                  value: '3',
+                  position: {
+                    start: {
+                      line: 39,
+                      column: 13,
+                      offset: 405
+                    },
+                    end: {
+                      line: 39,
+                      column: 14,
+                      offset: 406
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 39,
+                  column: 12,
+                  offset: 404
+                },
+                end: {
+                  line: 39,
+                  column: 15,
+                  offset: 407
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'text',
+              value: ':',
+              position: {
+                start: {
+                  line: 39,
+                  column: 15,
+                  offset: 407
+                },
+                end: {
+                  line: 39,
+                  column: 16,
+                  offset: 408
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 39,
+              column: 1,
+              offset: 393
+            },
+            end: {
+              line: 39,
+              column: 16,
+              offset: 408
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'code',
+          lang: 'javascript',
+          value: "console.log('sample code')",
+          position: {
+            start: {
+              line: 40,
+              column: 1,
+              offset: 409
+            },
+            end: {
+              line: 42,
+              column: 4,
+              offset: 453
+            },
+            indent: [1, 1]
+          }
+        }
+      ]
+    },
+    {
+      type: 'section',
+      name: 'Practice',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'This is a sample question with one gap:',
+              position: {
+                start: {
+                  line: 47,
+                  column: 1,
+                  offset: 472
+                },
+                end: {
+                  line: 47,
+                  column: 40,
+                  offset: 511
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 47,
+              column: 1,
+              offset: 472
+            },
+            end: {
+              line: 47,
+              column: 40,
+              offset: 511
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'questionGap',
+              value: '???',
+              position: {
+                start: {
+                  line: 49,
+                  column: 1,
+                  offset: 513
+                },
+                end: {
+                  line: 49,
+                  column: 4,
+                  offset: 516
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 49,
+              column: 1,
+              offset: 513
+            },
+            end: {
+              line: 49,
+              column: 4,
+              offset: 516
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'list',
+          ordered: false,
+          start: null,
+          loose: false,
+          children: [
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'correct',
+                      position: {
+                        start: {
+                          line: 51,
+                          column: 3,
+                          offset: 520
+                        },
+                        end: {
+                          line: 51,
+                          column: 10,
+                          offset: 527
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 51,
+                      column: 3,
+                      offset: 520
+                    },
+                    end: {
+                      line: 51,
+                      column: 10,
+                      offset: 527
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 51,
+                  column: 1,
+                  offset: 518
+                },
+                end: {
+                  line: 51,
+                  column: 10,
+                  offset: 527
+                },
+                indent: []
+              },
+              correct: true
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'incorrect',
+                      position: {
+                        start: {
+                          line: 52,
+                          column: 3,
+                          offset: 530
+                        },
+                        end: {
+                          line: 52,
+                          column: 12,
+                          offset: 539
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 52,
+                      column: 3,
+                      offset: 530
+                    },
+                    end: {
+                      line: 52,
+                      column: 12,
+                      offset: 539
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 52,
+                  column: 1,
+                  offset: 528
+                },
+                end: {
+                  line: 52,
+                  column: 12,
+                  offset: 539
+                },
+                indent: []
+              },
+              correct: true
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'not a chance',
+                      position: {
+                        start: {
+                          line: 53,
+                          column: 3,
+                          offset: 542
+                        },
+                        end: {
+                          line: 53,
+                          column: 15,
+                          offset: 554
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 53,
+                      column: 3,
+                      offset: 542
+                    },
+                    end: {
+                      line: 53,
+                      column: 15,
+                      offset: 554
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 53,
+                  column: 1,
+                  offset: 540
+                },
+                end: {
+                  line: 53,
+                  column: 15,
+                  offset: 554
+                },
+                indent: []
+              },
+              correct: true
+            }
+          ],
+          position: {
+            start: {
+              line: 51,
+              column: 1,
+              offset: 518
+            },
+            end: {
+              line: 53,
+              column: 15,
+              offset: 554
+            },
+            indent: [1, 1]
+          },
+          answers: true
+        }
+      ],
+      question: true
+    },
+    {
+      type: 'section',
+      name: 'Revision',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'This is a sample question with two gaps:',
+              position: {
+                start: {
+                  line: 58,
+                  column: 1,
+                  offset: 573
+                },
+                end: {
+                  line: 58,
+                  column: 41,
+                  offset: 613
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 58,
+              column: 1,
+              offset: 573
+            },
+            end: {
+              line: 58,
+              column: 41,
+              offset: 613
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'questionGap',
+              value: '???',
+              position: {
+                start: {
+                  line: 60,
+                  column: 1,
+                  offset: 615
+                },
+                end: {
+                  line: 60,
+                  column: 4,
+                  offset: 618
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 60,
+              column: 1,
+              offset: 615
+            },
+            end: {
+              line: 60,
+              column: 4,
+              offset: 618
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'questionGap',
+              value: '???',
+              position: {
+                start: {
+                  line: 62,
+                  column: 1,
+                  offset: 620
+                },
+                end: {
+                  line: 62,
+                  column: 4,
+                  offset: 623
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 62,
+              column: 1,
+              offset: 620
+            },
+            end: {
+              line: 62,
+              column: 4,
+              offset: 623
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'list',
+          ordered: false,
+          start: null,
+          loose: false,
+          children: [
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'correct',
+                      position: {
+                        start: {
+                          line: 64,
+                          column: 3,
+                          offset: 627
+                        },
+                        end: {
+                          line: 64,
+                          column: 10,
+                          offset: 634
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 64,
+                      column: 3,
+                      offset: 627
+                    },
+                    end: {
+                      line: 64,
+                      column: 10,
+                      offset: 634
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 64,
+                  column: 1,
+                  offset: 625
+                },
+                end: {
+                  line: 64,
+                  column: 10,
+                  offset: 634
+                },
+                indent: []
+              },
+              correct: true
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'also correct',
+                      position: {
+                        start: {
+                          line: 65,
+                          column: 3,
+                          offset: 637
+                        },
+                        end: {
+                          line: 65,
+                          column: 15,
+                          offset: 649
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 65,
+                      column: 3,
+                      offset: 637
+                    },
+                    end: {
+                      line: 65,
+                      column: 15,
+                      offset: 649
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 65,
+                  column: 1,
+                  offset: 635
+                },
+                end: {
+                  line: 65,
+                  column: 15,
+                  offset: 649
+                },
+                indent: []
+              },
+              correct: false
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'nah bro',
+                      position: {
+                        start: {
+                          line: 66,
+                          column: 3,
+                          offset: 652
+                        },
+                        end: {
+                          line: 66,
+                          column: 10,
+                          offset: 659
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 66,
+                      column: 3,
+                      offset: 652
+                    },
+                    end: {
+                      line: 66,
+                      column: 10,
+                      offset: 659
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 66,
+                  column: 1,
+                  offset: 650
+                },
+                end: {
+                  line: 66,
+                  column: 10,
+                  offset: 659
+                },
+                indent: []
+              },
+              correct: false
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'fam, just no',
+                      position: {
+                        start: {
+                          line: 67,
+                          column: 3,
+                          offset: 662
+                        },
+                        end: {
+                          line: 67,
+                          column: 15,
+                          offset: 674
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 67,
+                      column: 3,
+                      offset: 662
+                    },
+                    end: {
+                      line: 67,
+                      column: 15,
+                      offset: 674
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 67,
+                  column: 1,
+                  offset: 660
+                },
+                end: {
+                  line: 67,
+                  column: 15,
+                  offset: 674
+                },
+                indent: []
+              },
+              correct: false
+            }
+          ],
+          position: {
+            start: {
+              line: 64,
+              column: 1,
+              offset: 625
+            },
+            end: {
+              line: 67,
+              column: 15,
+              offset: 674
+            },
+            indent: [1, 1, 1]
+          },
+          answers: true
+        }
+      ],
+      question: true
+    },
+    {
+      type: 'section',
+      name: 'Quiz',
+      children: [
+        {
+          type: 'questionHeadline',
+          children: [
+            {
+              type: 'text',
+              value: 'Quiz title',
+              position: {
+                start: {
+                  line: 72,
+                  column: 5,
+                  offset: 693
+                },
+                end: {
+                  line: 72,
+                  column: 15,
+                  offset: 703
+                },
+                indent: []
+              }
+            }
+          ]
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'Sample quiz question',
+              position: {
+                start: {
+                  line: 74,
+                  column: 1,
+                  offset: 705
+                },
+                end: {
+                  line: 74,
+                  column: 21,
+                  offset: 725
+                },
+                indent: []
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 74,
+              column: 1,
+              offset: 705
+            },
+            end: {
+              line: 74,
+              column: 21,
+              offset: 725
+            },
+            indent: []
+          }
+        },
+        {
+          type: 'list',
+          ordered: false,
+          start: null,
+          loose: false,
+          children: [
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'correct',
+                      position: {
+                        start: {
+                          line: 76,
+                          column: 3,
+                          offset: 729
+                        },
+                        end: {
+                          line: 76,
+                          column: 10,
+                          offset: 736
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 76,
+                      column: 3,
+                      offset: 729
+                    },
+                    end: {
+                      line: 76,
+                      column: 10,
+                      offset: 736
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 76,
+                  column: 1,
+                  offset: 727
+                },
+                end: {
+                  line: 76,
+                  column: 10,
+                  offset: 736
+                },
+                indent: []
+              },
+              correct: true
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'emphasis',
+                      children: [
+                        {
+                          type: 'text',
+                          value: 'incorrect',
+                          position: {
+                            start: {
+                              line: 77,
+                              column: 4,
+                              offset: 740
+                            },
+                            end: {
+                              line: 77,
+                              column: 13,
+                              offset: 749
+                            },
+                            indent: []
+                          }
+                        }
+                      ],
+                      position: {
+                        start: {
+                          line: 77,
+                          column: 3,
+                          offset: 739
+                        },
+                        end: {
+                          line: 77,
+                          column: 14,
+                          offset: 750
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 77,
+                      column: 3,
+                      offset: 739
+                    },
+                    end: {
+                      line: 77,
+                      column: 14,
+                      offset: 750
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 77,
+                  column: 1,
+                  offset: 737
+                },
+                end: {
+                  line: 77,
+                  column: 14,
+                  offset: 750
+                },
+                indent: []
+              },
+              correct: false
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'not a ',
+                      position: {
+                        start: {
+                          line: 78,
+                          column: 3,
+                          offset: 753
+                        },
+                        end: {
+                          line: 78,
+                          column: 9,
+                          offset: 759
+                        },
+                        indent: []
+                      }
+                    },
+                    {
+                      type: 'inlineCode',
+                      value: 'chance',
+                      position: {
+                        start: {
+                          line: 78,
+                          column: 9,
+                          offset: 759
+                        },
+                        end: {
+                          line: 78,
+                          column: 17,
+                          offset: 767
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 78,
+                      column: 3,
+                      offset: 753
+                    },
+                    end: {
+                      line: 78,
+                      column: 17,
+                      offset: 767
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 78,
+                  column: 1,
+                  offset: 751
+                },
+                end: {
+                  line: 78,
+                  column: 17,
+                  offset: 767
+                },
+                indent: []
+              },
+              correct: false
+            },
+            {
+              type: 'listItem',
+              loose: false,
+              checked: null,
+              children: [
+                {
+                  type: 'paragraph',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'nope',
+                      position: {
+                        start: {
+                          line: 79,
+                          column: 3,
+                          offset: 770
+                        },
+                        end: {
+                          line: 79,
+                          column: 7,
+                          offset: 774
+                        },
+                        indent: []
+                      }
+                    }
+                  ],
+                  position: {
+                    start: {
+                      line: 79,
+                      column: 3,
+                      offset: 770
+                    },
+                    end: {
+                      line: 79,
+                      column: 7,
+                      offset: 774
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 79,
+                  column: 1,
+                  offset: 768
+                },
+                end: {
+                  line: 79,
+                  column: 7,
+                  offset: 774
+                },
+                indent: []
+              },
+              correct: false
+            }
+          ],
+          position: {
+            start: {
+              line: 76,
+              column: 1,
+              offset: 727
+            },
+            end: {
+              line: 79,
+              column: 7,
+              offset: 774
+            },
+            indent: [1, 1, 1]
+          },
+          answers: true
+        }
+      ],
+      question: true
+    },
+    {
+      type: 'section',
+      name: 'Footnotes',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'linkReference',
+              identifier: '1: paragraph',
+              referenceType: 'shortcut',
+              children: [
+                {
+                  type: 'text',
+                  value: '1: Paragraph',
+                  position: {
+                    start: {
+                      line: 84,
+                      column: 2,
+                      offset: 795
+                    },
+                    end: {
+                      line: 84,
+                      column: 14,
+                      offset: 807
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 84,
+                  column: 1,
+                  offset: 794
+                },
+                end: {
+                  line: 84,
+                  column: 15,
+                  offset: 808
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'text',
+              value: '\nSample explanation',
+              position: {
+                start: {
+                  line: 84,
+                  column: 15,
+                  offset: 808
+                },
+                end: {
+                  line: 85,
+                  column: 19,
+                  offset: 827
+                },
+                indent: [1]
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 84,
+              column: 1,
+              offset: 794
+            },
+            end: {
+              line: 85,
+              column: 19,
+              offset: 827
+            },
+            indent: [1]
+          }
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'linkReference',
+              identifier: '2: list',
+              referenceType: 'shortcut',
+              children: [
+                {
+                  type: 'text',
+                  value: '2: List',
+                  position: {
+                    start: {
+                      line: 87,
+                      column: 2,
+                      offset: 830
+                    },
+                    end: {
+                      line: 87,
+                      column: 9,
+                      offset: 837
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 87,
+                  column: 1,
+                  offset: 829
+                },
+                end: {
+                  line: 87,
+                  column: 10,
+                  offset: 838
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'text',
+              value: '\nSample list',
+              position: {
+                start: {
+                  line: 87,
+                  column: 10,
+                  offset: 838
+                },
+                end: {
+                  line: 88,
+                  column: 12,
+                  offset: 850
+                },
+                indent: [1]
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 87,
+              column: 1,
+              offset: 829
+            },
+            end: {
+              line: 88,
+              column: 12,
+              offset: 850
+            },
+            indent: [1]
+          }
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'linkReference',
+              identifier: '3: code',
+              referenceType: 'shortcut',
+              children: [
+                {
+                  type: 'text',
+                  value: '3: Code',
+                  position: {
+                    start: {
+                      line: 90,
+                      column: 2,
+                      offset: 853
+                    },
+                    end: {
+                      line: 90,
+                      column: 9,
+                      offset: 860
+                    },
+                    indent: []
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 90,
+                  column: 1,
+                  offset: 852
+                },
+                end: {
+                  line: 90,
+                  column: 10,
+                  offset: 861
+                },
+                indent: []
+              }
+            },
+            {
+              type: 'text',
+              value: '\nSample code',
+              position: {
+                start: {
+                  line: 90,
+                  column: 10,
+                  offset: 861
+                },
+                end: {
+                  line: 91,
+                  column: 12,
+                  offset: 873
+                },
+                indent: [1]
+              }
+            }
+          ],
+          position: {
+            start: {
+              line: 90,
+              column: 1,
+              offset: 852
+            },
+            end: {
+              line: 91,
+              column: 12,
+              offset: 873
+            },
+            indent: [1]
+          }
+        },
+        {
+          type: 'code',
+          lang: 'javascript',
+          value: 'var x = 10',
+          position: {
+            start: {
+              line: 92,
+              column: 1,
+              offset: 874
+            },
+            end: {
+              line: 94,
+              column: 4,
+              offset: 902
+            },
+            indent: [1, 1]
+          }
+        }
+      ]
+    }
+  ],
+  position: {
+    start: {
+      line: 1,
+      column: 1,
+      offset: 0
+    },
+    end: {
+      line: 95,
+      column: 1,
+      offset: 903
+    }
+  }
+}
 
 const { getCompiler } = require('./index')
 const json = getCompiler('insight').compileSync(ast)

--- a/packages/curriculum-compiler-json/index.sandbox.js
+++ b/packages/curriculum-compiler-json/index.sandbox.js
@@ -1,0 +1,116 @@
+// Use this sandbox to play with the parser
+const parser = require('../../packages/curriculum-parser/index')
+
+const ast = parser.getParser('insight')
+  .parseSync(`---
+author: jfarmer
+
+levels:
+
+  - beginner
+  - basic
+  - medium
+  - advanced
+
+type: normal
+
+category: must-know
+
+links:
+  - '[Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}'
+
+parent: removing-keys-from-a-binary-search-tree
+
+---
+# Balanced vs. \`Unbalanced\` Binary Trees
+
+---
+## Content
+
+A binary tree is called *balanced* if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases "approximately the same" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application.
+
+This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree.
+
+Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:
+
+![unbalanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)
+
+In order to balance the above tree, the \`10-15-13\` subtree has to be "rotated":
+
+![balanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)
+
+
+This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching *on average*, but a linear-time worst case.
+
+Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees[1] and red-black trees[2].
+
+---
+## Practice
+
+Blah blah blah
+
+\`\`\`javascript
+Blah blah
+???
+\`\`\`
+
+* abc
+* yoli
+* yes
+
+---
+## Revision
+
+Which of the following data structures is a type of *maximally-unbalanced* binary tree?
+
+???
+
+* Ordered linked list
+* Ordered array
+* Weighted graph
+* Max-heap
+
+---
+## Quiz
+
+### what is the output of \`the\` following script?
+
+\`\`\`bash
+#!/bin/bash
+a=1
+{ a=2 }
+echo $a
+\`\`\`
+
+There is a list here:
+- abc
+- def
+- abcd
+
+* "Error: unexpected end of file"
+* \`1\`
+* 2
+* $a
+
+---
+## Footnotes
+
+[1: AVL tree]
+Self-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.
+
+[2: Red-Black tree]
+Self-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.
+
+[3: Blah blah]
+This is the third footnote
+
+with code:
+\`\`\`javascript
+var x = 10
+\`\`\`
+`)
+
+const { getCompiler } = require('./index')
+const json = getCompiler('insight').compileSync(ast)
+
+console.log(json)

--- a/packages/curriculum-compiler-json/package.json
+++ b/packages/curriculum-compiler-json/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "curriculum-compiler-json",
+  "version": "1.0.0",
+  "description": "Compile Enki Curriculum AST to JSON object",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest --notify"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enkidevs/curriculum-processors.git"
+  },
+  "keywords": [
+    "enki",
+    "curriculum",
+    "compiler",
+    "json"
+  ],
+  "author": "loopiezlol <loopiezlol@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/enkidevs/curriculum-processors/issues"
+  },
+  "homepage": "https://github.com/enkidevs/curriculum-processors#readme",
+  "dependencies": {
+    "@enkidevs/curriculum-compiler-string": "^2.0.1",
+    "@enkidevs/curriculum-helpers": "^1.6.0"
+  },
+  "devDependencies": {
+    "jest": "^22.4.3",
+    "jest-in-case": "^1.0.2",
+    "jsonfile": "^4.0.0"
+  },
+  "jest": {
+    "testRegex": "/.*__tests__/.*\\.test.js$"
+  }
+}

--- a/packages/curriculum-compiler-json/package.json
+++ b/packages/curriculum-compiler-json/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/enkidevs/curriculum-processors#readme",
   "dependencies": {
     "@enkidevs/curriculum-compiler-string": "^2.0.1",
-    "@enkidevs/curriculum-helpers": "^1.6.0"
+    "@enkidevs/curriculum-helpers": "^1.6.0",
+    "unist-builder": "^1.0.2"
   },
   "devDependencies": {
     "jest": "^22.4.3",

--- a/packages/curriculum-helpers/lib/index.js
+++ b/packages/curriculum-helpers/lib/index.js
@@ -1,9 +1,11 @@
 const contentTypes = require('./content-types')
 const compactAst = require('./compact-ast')
 const sectionNames = require('./section-names')
+const questionTypes = require('./question-types')
 
 module.exports = {
   contentTypes,
   compactAst,
-  sectionNames
+  sectionNames,
+  questionTypes
 }

--- a/packages/curriculum-helpers/lib/question-types.js
+++ b/packages/curriculum-helpers/lib/question-types.js
@@ -1,0 +1,4 @@
+module.exports = {
+  PRACTICE: 'practice',
+  REVISION: 'revision'
+}

--- a/packages/curriculum-helpers/lib/section-names.js
+++ b/packages/curriculum-helpers/lib/section-names.js
@@ -4,5 +4,6 @@ module.exports = {
   REVISION: 'Revision',
   PRACTICE: 'Practice',
   QUIZ: 'Quiz',
-  GAME_CONTENT: 'Game Content'
+  GAME_CONTENT: 'Game Content',
+  EXERCISE: 'Exercise'
 }

--- a/packages/curriculum-parser/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-parser/__tests__/fixtures/insight/sample/ast.json
@@ -337,7 +337,7 @@
                   ]
                 }
               ],
-              "correct": false
+              "correct": true
             },
             {
               "type": "listItem",

--- a/packages/curriculum-parser/__tests__/fixtures/question/quiz/ast.json
+++ b/packages/curriculum-parser/__tests__/fixtures/question/quiz/ast.json
@@ -20,15 +20,6 @@
       ]
     },
     {
-      "type": "paragraph",
-      "children": [
-        {
-          "type": "questionGap",
-          "value": "???"
-        }
-      ]
-    },
-    {
       "type": "list",
       "ordered": false,
       "start": null,

--- a/packages/curriculum-parser/__tests__/fixtures/question/quiz/text.md
+++ b/packages/curriculum-parser/__tests__/fixtures/question/quiz/text.md
@@ -1,9 +1,7 @@
 ### which algorithm is to be use in the following scenario?
+
 Consider a complete, weighted graph. If we want to compute its minimum spanning tree,
 which starts from a given node we choose, which algorithm should we use?
-
-
-???
 
 * Prim’s algorithm
 * Kruskal’s algorithm

--- a/packages/curriculum-parser/plugins/question/answers.js
+++ b/packages/curriculum-parser/plugins/question/answers.js
@@ -12,16 +12,14 @@ module.exports = function questionAnswers () {
   }
 
   function parseQuestionAnswersList (temp) {
-    return function one(node, index, parent) {
-      if (node.type === 'list'
-        && !node.ordered
-        && index === parent.children.length - 1
-        && (
-          parent.type === 'root' ||
-          (parent.type === 'section' && parent.question)
-        )
+    return function one (node, index, parent) {
+      if (
+        node.type === 'list' &&
+        !node.ordered &&
+        index === parent.children.length - 1 &&
+        (parent.type === 'root' ||
+          (parent.type === 'section' && parent.question))
       ) {
-
         visit(parent, 'questionGap', () => {
           temp.questionGapCount += 1
         })
@@ -33,20 +31,25 @@ module.exports = function questionAnswers () {
   }
 
   function parseQuestionAnswersListItems (temp) {
-    return function one(node, index, parent) {
-      if (node.type === 'listItem'
-      && parent.type === 'list'
-      && parent.answers) {
-
-        const correct = temp.questionGapCount > 0
-        temp.questionGapCount -= 1
-        return Object.assign(
-          {},
-          node,
-          {correct}
-        )
+    return function one (node, index, parent) {
+      if (
+        node.type === 'listItem' &&
+        parent.type === 'list' &&
+        parent.answers
+      ) {
+        const correct = getCorrectAndUpdateCount(temp, index)
+        return Object.assign({}, node, { correct })
       }
       return node
     }
+  }
+
+  function getCorrectAndUpdateCount (temp, index) {
+    let correct = index === 0
+    if (temp.questionGapCount > 0) {
+      correct = true
+      temp.questionGapCount -= 1
+    }
+    return correct
   }
 }


### PR DESCRIPTION
This PR:
- adds one more package to the `curriculum-processors` suite. closes #1 
- modifies the `curriculum-parser` such that questions with no ??? gaps will have their first answer `correct: true`


This package, obvious from its name, parses insight AST into JSON.

The schema of the returned JSON is the following:
```
{
  "metadata": {
    "author": "jfarmer",
    "levels": [ "beginner" ],
    "type": "normal",
    "category": "must-know",
    "links": [
      {
        "name": "Why is it safer to keep the tree balanced?",
        "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
        "nature": "website"
      }
    ],
    "parent": :slug",
    "standards": {
        "sql.define-columns.1": 1000,
        "sql.define-columns.2": 1000
      },
  },
  "headline": "Insight `title`",
  "content": "...",
  "gameContent": "...",
  "exercise": "...",
  "practice": {
     "rawText": "...",
     "question": "question without answers",
     "answers": [ "ans1", "ans2", "ans3"]
  },
   "revision": {
      "rawText": "...",
      "question": "question without answers",
      "answers": [ "ans1", "ans2", "ans3"]
  },
  "quiz": {
    "rawText": "....",
    "headline": "just the headline",
    "question": "just the question text",
    "answers": [ "ans1", "ans2", "ans3"]
  },
  "footnotes": {
    "rawText": "...",
    "items": [
      {
        "number": "1",
        "name": " AVL tree",
        "text": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.\n\n"
      },
      {
        "number": "2",
        "name": " Red-Black tree",
        "text": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.\n\n"
      }
    ]
  }
}
```

Todo:
- [ ] publish
- [ ] add more tests if needed ?
- [x] documentation