### PR TITLE
Adding a flag for editor to ignore jest syntax

### DIFF
--- a/packages/curriculum-compiler-string/__tests__/insight/stringify-sync.test.js
+++ b/packages/curriculum-compiler-string/__tests__/insight/stringify-sync.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const jestInCase = require('jest-in-case')

--- a/packages/curriculum-compiler-string/__tests__/insight/stringify.test.js
+++ b/packages/curriculum-compiler-string/__tests__/insight/stringify.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const jestInCase = require('jest-in-case')

--- a/packages/curriculum-compiler-string/__tests__/question/stringify-sync.test.js
+++ b/packages/curriculum-compiler-string/__tests__/question/stringify-sync.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const jestInCase = require('jest-in-case')

--- a/packages/curriculum-compiler-string/__tests__/question/stringify.test.js
+++ b/packages/curriculum-compiler-string/__tests__/question/stringify.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const jestInCase = require('jest-in-case')

--- a/packages/curriculum-helpers/__tests__/compact-ast.test.js
+++ b/packages/curriculum-helpers/__tests__/compact-ast.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const compactAst = require('../lib/compact-ast')
 
 describe('Compact AST', () => {

--- a/packages/curriculum-parser/__tests__/insight/error-headline.test.js
+++ b/packages/curriculum-parser/__tests__/insight/error-headline.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const { contentTypes } = require('@enkidevs/curriculum-helpers')

--- a/packages/curriculum-parser/__tests__/insight/error-yaml.test.js
+++ b/packages/curriculum-parser/__tests__/insight/error-yaml.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const { contentTypes } = require('@enkidevs/curriculum-helpers')

--- a/packages/curriculum-parser/__tests__/insight/parse-sync.test.js
+++ b/packages/curriculum-parser/__tests__/insight/parse-sync.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const jestInCase = require('jest-in-case')

--- a/packages/curriculum-parser/__tests__/insight/parse.test.js
+++ b/packages/curriculum-parser/__tests__/insight/parse.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const path = require('path')
 const fs = require('fs')
 const jestInCase = require('jest-in-case')


### PR DESCRIPTION
These flags prevent VSCode from seeing functions like expect and .toBe as undefined.