### PR TITLE
Adding question-type AST ➡️ JSON compiler

### DIFF
--- a/packages/curriculum-compiler-json/__tests__/fixtures/question/sample/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/question/sample/ast.json
@@ -1,0 +1,123 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 2,
+      "children": [
+        {
+          "type": "text",
+          "value": "Revision"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Which of the following data structures is a type of "
+        },
+        {
+          "type": "emphasis",
+          "children": [
+            {
+              "type": "text",
+              "value": "maximally-unbalanced"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": " binary tree?"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "questionGap",
+          "value": "???"
+        }
+      ]
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Ordered linked list"
+                }
+              ]
+            }
+          ],
+          "correct": true
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Ordered array"
+                }
+              ]
+            }
+          ],
+          "correct": false
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Weighted graph"
+                }
+              ]
+            }
+          ],
+          "correct": false
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Max-heap"
+                }
+              ]
+            }
+          ],
+          "correct": false
+        }
+      ],
+      "answers": true
+    }
+  ]
+}

--- a/packages/curriculum-compiler-json/__tests__/fixtures/question/sample/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/question/sample/parsed.json
@@ -1,0 +1,30 @@
+{
+  "revision": {
+    "rawText":
+      "## Revision\n\nWhich of the following data structures is a type of *maximally-unbalanced* binary tree?\n\n???\n\n* Ordered linked list\n* Ordered array\n* Weighted graph\n* Max-heap\n",
+    "question":
+      "Which of the following data structures is a type of *maximally-unbalanced* binary tree?\n\n???\n",
+    "answers": [
+      {
+        "text": "Ordered linked list",
+        "correct": true,
+        "correctIndex": 0
+      },
+      {
+        "text": "Ordered array",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "Weighted graph",
+        "correct": false,
+        "correctIndex": null
+      },
+      {
+        "text": "Max-heap",
+        "correct": false,
+        "correctIndex": null
+      }
+    ]
+  }
+}

--- a/packages/curriculum-compiler-json/__tests__/question/compile-sync.test.js
+++ b/packages/curriculum-compiler-json/__tests__/question/compile-sync.test.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const jestInCase = require('jest-in-case');
+const jsonfile = require('jsonfile');
+const { contentTypes } = require('@enkidevs/curriculum-helpers');
+const { getCompiler } = require('../../index');
+
+const fixturePath = (dir, name) =>
+  path.join(__dirname, '../', 'fixtures', 'question', dir, name);
+
+jestInCase(
+  'Insight AST to JSON Compilation (Sync)',
+  fixture => {
+    const compiler = getCompiler(contentTypes.QUESTION);
+    const json = compiler.compileSync(fixture.ast);
+    expect(json).toEqual(fixture.parsed);
+  },
+  ['sample'].map(dir => ({
+    parsed: jsonfile.readFileSync(fixturePath(dir, 'parsed.json')),
+    ast: jsonfile.readFileSync(fixturePath(dir, 'ast.json')),
+  }))
+);

--- a/packages/curriculum-compiler-json/compilers/question.js
+++ b/packages/curriculum-compiler-json/compilers/question.js
@@ -11,7 +11,8 @@ module.exports = function question(node, type) {
   const answers = getAnswersFromNode(node);
   const q = compileNodeToQuestionMarkdown({
     children: node.children.filter(
-      child => child.type !== 'list' && !child.answers
+      child =>
+        child.type !== 'heading' && child.type !== 'list' && !child.answers
     ),
   });
 

--- a/packages/curriculum-compiler-json/index.js
+++ b/packages/curriculum-compiler-json/index.js
@@ -29,6 +29,7 @@ const nodeSectionMap = {
 const nodeTypeMap = {
   yaml: node => compilers.metadata(node),
   headline: node => compilers.headline(node),
+  heading: node => compilers.heading(node),
   section: node => {
     if (!node.name) {
       throw new Error(`Invalid section node with no name`);
@@ -63,12 +64,38 @@ function compileInsight(ast) {
   return json;
 }
 
+function compileQuestion(ast) {
+  if (!ast || !ast.children) {
+    throw new Error('Missing or invalid AST');
+  }
+
+  // Don't mutate parameter
+  const questionAst = Object.assign({}, ast);
+
+  const heading = questionAst.children.find(node => node.type === 'heading');
+
+  const name = heading.children[0].value;
+
+  // Wrap question-type ast in section node data
+  questionAst.name = name;
+  questionAst.type = 'section';
+  questionAst.question = true;
+
+  const json = compilers.question(questionAst, name.toLowerCase());
+
+  return json;
+}
+
 function getCompiler(type) {
   let compileSync;
   switch (type) {
     case contentTypes.EXERCISE:
     case contentTypes.INSIGHT: {
       compileSync = compileInsight;
+      break;
+    }
+    case contentTypes.QUESTION: {
+      compileSync = compileQuestion;
       break;
     }
     default:

--- a/packages/curriculum-compiler-json/index.sandbox.js
+++ b/packages/curriculum-compiler-json/index.sandbox.js
@@ -4,72 +4,127 @@ const ast = {
   type: 'root',
   children: [
     {
-      type: 'yaml',
-      value:
-        "author: milesflo\n\nlevels:\n\n  - beginner\n\n  - basic\n\ntype: exercise\n\nlink: https://www.codewars.com/kata/classy-classes\nlinkType: codewars\nstandards:\n\n  javascript.execution-context.2: 1000\n  javascript.execution-context.3: 1000\n  javascript.execution-context.4: 1000\n\nlinks:\n\n  - '[MDN - this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this)'",
-      data: {
-        parsedValue: {
-          author: 'milesflo',
-          levels: ['beginner', 'basic'],
-          type: 'exercise',
-          link: 'https://www.codewars.com/kata/classy-classes',
-          linkType: 'codewars',
-          standards: {
-            'javascript.execution-context.2': 1000,
-            'javascript.execution-context.3': 1000,
-            'javascript.execution-context.4': 1000,
-          },
-          links: [
-            {
-              name: 'MDN - this',
-              url:
-                'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this',
-              nature: 'website',
-            },
-          ],
-        },
-      },
-    },
-    {
-      type: 'headline',
+      type: 'heading',
+      depth: 2,
       children: [
         {
           type: 'text',
-          value: 'JS Practice ',
-        },
-        {
-          type: 'inlineCode',
-          value: 'this',
+          value: 'Revision',
         },
       ],
     },
     {
-      type: 'section',
-      name: 'Exercise',
+      type: 'paragraph',
       children: [
         {
-          type: 'paragraph',
+          type: 'text',
+          value: 'Which of the following data structures is a type of ',
+        },
+        {
+          type: 'emphasis',
           children: [
             {
               type: 'text',
-              value: 'Explore the ',
-            },
-            {
-              type: 'inlineCode',
-              value: 'this',
-            },
-            {
-              type: 'text',
-              value: ' operator in JavaScript with Constructor functions',
+              value: 'maximally-unbalanced',
             },
           ],
         },
+        {
+          type: 'text',
+          value: ' binary tree?',
+        },
       ],
+    },
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'questionGap',
+          value: '???',
+        },
+      ],
+    },
+    {
+      type: 'list',
+      ordered: false,
+      start: null,
+      loose: false,
+      children: [
+        {
+          type: 'listItem',
+          loose: false,
+          checked: null,
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'Ordered linked list',
+                },
+              ],
+            },
+          ],
+          correct: true,
+        },
+        {
+          type: 'listItem',
+          loose: false,
+          checked: null,
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'Ordered array',
+                },
+              ],
+            },
+          ],
+          correct: false,
+        },
+        {
+          type: 'listItem',
+          loose: false,
+          checked: null,
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'Weighted graph',
+                },
+              ],
+            },
+          ],
+          correct: false,
+        },
+        {
+          type: 'listItem',
+          loose: false,
+          checked: null,
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'Max-heap',
+                },
+              ],
+            },
+          ],
+          correct: false,
+        },
+      ],
+      answers: true,
     },
   ],
 };
 
 const { getCompiler } = require('./index');
-const json = getCompiler('exercise').compileSync(ast);
+const json = getCompiler('question').compileSync(ast);
 
 console.log(JSON.stringify(json, null, 2));


### PR DESCRIPTION
- [x] Add case for handling `contentTypes.QUESTION` in `getCompiler` method
- [x] Add `compileQuestion` function
    - Function expects [question-type AST](https://github.com/enkidevs/curriculum-processors/blob/master/packages/curriculum-parser-markdown/index.js#L12)
    - Wraps question AST in a `section` node, as it would be in an Insight-type AST
    - Returns the result of the question compiler
- [x] Alter question compiler to filter out `heading` node when parsing question to string.
