### PR TITLE
Padding YAML with Blank Lines

### DIFF
--- a/packages/curriculum-compiler-string/plugins/insight/yaml.js
+++ b/packages/curriculum-compiler-string/plugins/insight/yaml.js
@@ -16,7 +16,8 @@ module.exports = function yaml() {
           }
           const yml = jsYaml
             .safeDump(node.data.parsedValue)
-            .trim().replace(/\n/g, '\n\n');
+            .trim()
+            .replace(/\n/g, '\n\n');
           return `---\n${yml}\n---`;
         }
         return undefined;

--- a/packages/curriculum-compiler-string/plugins/insight/yaml.js
+++ b/packages/curriculum-compiler-string/plugins/insight/yaml.js
@@ -14,8 +14,8 @@ module.exports = function yaml() {
               link => `[${link.name}](${link.url}){${link.nature}}`
             );
           }
-          const yml = jsYaml.safeDump(node.data.parsedValue);
-          return `---\n${yml}---`;
+          const yml = jsYaml.safeDump(node.data.parsedValue).trim().replace(/\n/g, '\n\n');
+          return `---\n${yml}\n---`;
         }
         return undefined;
       };

--- a/packages/curriculum-compiler-string/plugins/insight/yaml.js
+++ b/packages/curriculum-compiler-string/plugins/insight/yaml.js
@@ -14,7 +14,9 @@ module.exports = function yaml() {
               link => `[${link.name}](${link.url}){${link.nature}}`
             );
           }
-          const yml = jsYaml.safeDump(node.data.parsedValue).trim().replace(/\n/g, '\n\n');
+          const yml = jsYaml
+            .safeDump(node.data.parsedValue)
+            .trim().replace(/\n/g, '\n\n');
           return `---\n${yml}\n---`;
         }
         return undefined;


### PR DESCRIPTION
Currently our insight compiler will produce YAML that is tightly blocked together, though it is more readable to have our YAML separated by blank lines. The proposed change will do this.

Before:
```yaml
---
author: alexjmackey
levels:
  - beginner
type: normal
inAlgoPool: false
category: must-know
---
```

After:
```yaml
---
author: alexjmackey

levels:

  - beginner

type: normal

inAlgoPool: false

category: must-know
---
```