### PR TITLE
Padding YAML with blank lines for readability

### DIFF
--- a/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/stringified.md
+++ b/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/stringified.md
@@ -1,16 +1,28 @@
 ---
 author: jfarmer
+
 levels:
+
   - beginner
+
   - basic
+
   - medium
+
   - advanced
+
 type: normal
+
 category: must-know
+
 links:
+
   - >-
+
     [Why is it safer to keep the tree
+
     balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}
+
 parent: removing-keys-from-a-binary-search-tree
 ---
 

--- a/packages/curriculum-compiler-string/plugins/insight/yaml.js
+++ b/packages/curriculum-compiler-string/plugins/insight/yaml.js
@@ -14,8 +14,11 @@ module.exports = function yaml() {
               link => `[${link.name}](${link.url}){${link.nature}}`
             );
           }
-          const yml = jsYaml.safeDump(node.data.parsedValue);
-          return `---\n${yml}---`;
+          const yml = jsYaml
+            .safeDump(node.data.parsedValue)
+            .trim()
+            .replace(/\n/g, '\n\n');
+          return `---\n${yml}\n---`;
         }
         return undefined;
       };


### PR DESCRIPTION
Currently, our insight compiler will produce YAML that is tightly blocked together. This is not compliant with the style guide that content contributors follow... It is more readable to have our YAML separated by blank lines.

The proposed change will do this for us... With this, we could write an insight linter at some point down the line.

Before:
```yaml
---
author: alexjmackey
levels:
  - beginner
type: normal
inAlgoPool: false
category: must-know
---
```

After:
```yaml
---
author: alexjmackey

levels:

  - beginner

type: normal

inAlgoPool: false

category: must-know
---
```