### PR TITLE
Update all da deps

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,9 +1,2 @@
 extends:
   - '@enkidevs/eslint-config-backend'
-rules:
-  import/no-extraneous-dependencies: off # because tests use 'jest-in-case' and 'jsonfile'
-  node/no-extraneous-require:
-    - error
-    - allowModules:
-        - jest-in-case
-        - jsonfile

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Build: [![CircleCI](https://circleci.com/gh/enkidevs/curriculum-processors.svg?style=svg)](https://circleci.com/gh/enkidevs/curriculum-processors)
+
 # Enki Curriculum Processors
 
 Note: The language used here follows this pattern:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,23 +3,32 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.49"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
+      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "@enkidevs/assert-restricted-branch": {
@@ -29,28 +38,1035 @@
       "dev": true
     },
     "@enkidevs/eslint-config-backend": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@enkidevs/eslint-config-backend/-/eslint-config-backend-0.1.1.tgz",
-      "integrity": "sha512-c4RnoUcd7almp/wct5G2WYQPPITAdeyAJeqtWo7LYuAOxNNapGZxoaqxMorzZ9NsPC75tOMqH+N2eVkWXJ0TSg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@enkidevs/eslint-config-backend/-/eslint-config-backend-0.3.1.tgz",
+      "integrity": "sha512-UXtZs96FdvV1e3ZzTHeFIvieQsbYWJgcGD1q2j1nDZcqNFplsa5Ljv8xFYR8nA4xPFf8mq0lE1AcrS08LTOqTw==",
       "dev": true,
       "requires": {
-        "@enkidevs/eslint-config-base": "0.1.1",
-        "eslint-config-airbnb-base": "13.1.0",
-        "eslint-plugin-node": "7.0.1",
-        "eslint-plugin-security": "1.4.0"
+        "@enkidevs/eslint-config-base": "^0.3.1",
+        "eslint-config-airbnb-base": "^13.1.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-security": "^1.4.0"
       }
     },
     "@enkidevs/eslint-config-base": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@enkidevs/eslint-config-base/-/eslint-config-base-0.1.1.tgz",
-      "integrity": "sha512-YuB+qj5wqz2FIgjxsK9nR6h3589J6apofrbyVu1JpD9n7pgx/KyshE70Vdo0Zdqdt/Z8t9csJrP6HLmmQ/CaeQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@enkidevs/eslint-config-base/-/eslint-config-base-0.3.1.tgz",
+      "integrity": "sha512-8ajRcqsJvmSnq57kdnXf270EoECHuqSXtuILH9cUzMGJmlxJNTn3L5DeXkXSJDvxFFbsWJ6wRgs+Gf6NW2kY1g==",
       "dev": true,
       "requires": {
-        "eslint-config-prettier": "2.10.0",
-        "eslint-plugin-import": "2.14.0",
-        "eslint-plugin-jest": "21.22.0",
-        "eslint-plugin-prettier": "2.6.2",
-        "eslint-plugin-promise": "4.0.1"
+        "eslint-config-prettier": "^4.1.0",
+        "eslint-plugin-import": "^2.16.0",
+        "eslint-plugin-jest": "^22.3.0",
+        "eslint-plugin-prettier": "^3.0.1",
+        "eslint-plugin-promise": "^4.0.1"
+      }
+    },
+    "@lerna/add": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.13.1.tgz",
+      "integrity": "sha512-cXk42YbuhzEnADCK8Qte5laC9Qo03eJLVnr0qKY85jQUM/T4URe3IIUemqpg0CpVATrB+Vz+iNdeqw9ng1iALw==",
+      "dev": true,
+      "requires": {
+        "@lerna/bootstrap": "3.13.1",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "dedent": "^0.7.0",
+        "npm-package-arg": "^6.1.0",
+        "p-map": "^1.2.0",
+        "pacote": "^9.5.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/batch-packages": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.13.0.tgz",
+      "integrity": "sha512-TgLBTZ7ZlqilGnzJ3xh1KdAHcySfHytgNRTdG9YomfriTU6kVfp1HrXxKJYVGs7ClPUNt2CTFEOkw0tMBronjw==",
+      "dev": true,
+      "requires": {
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/bootstrap": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.13.1.tgz",
+      "integrity": "sha512-mKdi5Ds5f82PZwEFyB9/W60I3iELobi1i87sTeVrbJh/um7GvqpSPy7kG/JPxyOdMpB2njX6LiJgw+7b6BEPWw==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/has-npm-version": "3.13.0",
+        "@lerna/npm-install": "3.13.0",
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/rimraf-dir": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/symlink-binary": "3.13.0",
+        "@lerna/symlink-dependencies": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "dedent": "^0.7.0",
+        "get-port": "^3.2.0",
+        "multimatch": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "p-finally": "^1.0.0",
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0",
+        "p-waterfall": "^1.0.0",
+        "read-package-tree": "^5.1.6",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/changed": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.1.tgz",
+      "integrity": "sha512-BRXitEJGOkoudbxEewW7WhjkLxFD+tTk4PrYpHLyCBk63pNTWtQLRE6dc1hqwh4emwyGncoyW6RgXfLgMZgryw==",
+      "dev": true,
+      "requires": {
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/listable": "3.13.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/version": "3.13.1"
+      }
+    },
+    "@lerna/check-working-tree": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.13.0.tgz",
+      "integrity": "sha512-dsdO15NXX5To+Q53SYeCrBEpiqv4m5VkaPZxbGQZNwoRen1MloXuqxSymJANQn+ZLEqarv5V56gydebeROPH5A==",
+      "dev": true,
+      "requires": {
+        "@lerna/describe-ref": "3.13.0",
+        "@lerna/validation-error": "3.13.0"
+      }
+    },
+    "@lerna/child-process": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.0.tgz",
+      "integrity": "sha512-0iDS8y2jiEucD4fJHEzKoc8aQJgm7s+hG+0RmDNtfT0MM3n17pZnf5JOMtS1FJp+SEXOjMKQndyyaDIPFsnp6A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.1",
+        "execa": "^1.0.0",
+        "strong-log-transformer": "^2.0.0"
+      }
+    },
+    "@lerna/clean": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.13.1.tgz",
+      "integrity": "sha512-myGIaXv7RUO2qCFZXvx8SJeI+eN6y9SUD5zZ4/LvNogbOiEIlujC5lUAqK65rAHayQ9ltSa/yK6Xv510xhZXZQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/rimraf-dir": "3.13.0",
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0",
+        "p-waterfall": "^1.0.0"
+      }
+    },
+    "@lerna/cli": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
+      "integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+      "dev": true,
+      "requires": {
+        "@lerna/global-options": "3.13.0",
+        "dedent": "^0.7.0",
+        "npmlog": "^4.1.2",
+        "yargs": "^12.0.1"
+      }
+    },
+    "@lerna/collect-updates": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.13.0.tgz",
+      "integrity": "sha512-uR3u6uTzrS1p46tHQ/mlHog/nRJGBqskTHYYJbgirujxm6FqNh7Do+I1Q/7zSee407G4lzsNxZdm8IL927HemQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/describe-ref": "3.13.0",
+        "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
+        "slash": "^1.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/command": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.13.1.tgz",
+      "integrity": "sha512-SYWezxX+iheWvzRoHCrbs8v5zHPaxAx3kWvZhqi70vuGsdOVAWmaG4IvHLn11ztS+Vpd5PM+ztBWSbnykpLFKQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/project": "3.13.1",
+        "@lerna/validation-error": "3.13.0",
+        "@lerna/write-log-file": "3.13.0",
+        "dedent": "^0.7.0",
+        "execa": "^1.0.0",
+        "is-ci": "^1.0.10",
+        "lodash": "^4.17.5",
+        "npmlog": "^4.1.2"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          }
+        }
+      }
+    },
+    "@lerna/conventional-commits": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.13.0.tgz",
+      "integrity": "sha512-BeAgcNXuocmLhPxnmKU2Vy8YkPd/Uo+vu2i/p3JGsUldzrPC8iF3IDxH7fuXpEFN2Nfogu7KHachd4tchtOppA==",
+      "dev": true,
+      "requires": {
+        "@lerna/validation-error": "3.13.0",
+        "conventional-changelog-angular": "^5.0.3",
+        "conventional-changelog-core": "^3.1.6",
+        "conventional-recommended-bump": "^4.0.4",
+        "fs-extra": "^7.0.0",
+        "get-stream": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "pify": "^3.0.0",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/create": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.13.1.tgz",
+      "integrity": "sha512-pLENMXgTkQuvKxAopjKeoLOv9fVUCnpTUD7aLrY5d95/1xqSZlnsOcQfUYcpMf3GpOvHc8ILmI5OXkPqjAf54g==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "camelcase": "^5.0.0",
+        "dedent": "^0.7.0",
+        "fs-extra": "^7.0.0",
+        "globby": "^8.0.1",
+        "init-package-json": "^1.10.3",
+        "npm-package-arg": "^6.1.0",
+        "p-reduce": "^1.0.0",
+        "pacote": "^9.5.0",
+        "pify": "^3.0.0",
+        "semver": "^5.5.0",
+        "slash": "^1.0.0",
+        "validate-npm-package-license": "^3.0.3",
+        "validate-npm-package-name": "^3.0.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
+    "@lerna/create-symlink": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.13.0.tgz",
+      "integrity": "sha512-PTvg3jAAJSAtLFoZDsuTMv1wTOC3XYIdtg54k7uxIHsP8Ztpt+vlilY/Cni0THAqEMHvfiToel76Xdta4TU21Q==",
+      "dev": true,
+      "requires": {
+        "cmd-shim": "^2.0.2",
+        "fs-extra": "^7.0.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/describe-ref": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.0.tgz",
+      "integrity": "sha512-UJefF5mLxLae9I2Sbz5RLYGbqbikRuMqdgTam0MS5OhXnyuuKYBUpwBshCURNb1dPBXTQhSwc7+oUhORx8ojCg==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/diff": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.13.1.tgz",
+      "integrity": "sha512-cKqmpONO57mdvxtp8e+l5+tjtmF04+7E+O0QEcLcNUAjC6UR2OSM77nwRCXDukou/1h72JtWs0jjcdYLwAmApg==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/validation-error": "3.13.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/exec": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.13.1.tgz",
+      "integrity": "sha512-I34wEP9lrAqqM7tTXLDxv/6454WFzrnXDWpNDbiKQiZs6SIrOOjmm6I4FiQsx+rU3o9d+HkC6tcUJRN5mlJUgA==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/validation-error": "3.13.0"
+      }
+    },
+    "@lerna/filter-options": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.13.0.tgz",
+      "integrity": "sha512-SRp7DCo9zrf+7NkQxZMkeyO1GRN6GICoB9UcBAbXhLbWisT37Cx5/6+jh49gYB63d/0/WYHSEPMlheUrpv1Srw==",
+      "dev": true,
+      "requires": {
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/filter-packages": "3.13.0",
+        "dedent": "^0.7.0"
+      }
+    },
+    "@lerna/filter-packages": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
+      "integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/validation-error": "3.13.0",
+        "multimatch": "^2.1.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/get-npm-exec-opts": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
+      "integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/get-packed": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
+      "integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.8"
+      },
+      "dependencies": {
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/github-client": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.1.tgz",
+      "integrity": "sha512-iPLUp8FFoAKGURksYEYZzfuo9TRA+NepVlseRXFaWlmy36dCQN20AciINpoXiXGoHcEUHXUKHQvY3ARFdMlf3w==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@octokit/plugin-enterprise-rest": "^2.1.1",
+        "@octokit/rest": "^16.16.0",
+        "git-url-parse": "^11.1.2",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/global-options": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
+      "integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
+      "dev": true
+    },
+    "@lerna/has-npm-version": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.0.tgz",
+      "integrity": "sha512-Oqu7DGLnrMENPm+bPFGOHnqxK8lCnuYr6bk3g/CoNn8/U0qgFvHcq6Iv8/Z04TsvleX+3/RgauSD2kMfRmbypg==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/import": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.13.1.tgz",
+      "integrity": "sha512-A1Vk1siYx1XkRl6w+zkaA0iptV5TIynVlHPR9S7NY0XAfhykjztYVvwtxarlh6+VcNrO9We6if0+FXCrfDEoIg==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "dedent": "^0.7.0",
+        "fs-extra": "^7.0.0",
+        "p-map-series": "^1.0.0"
+      }
+    },
+    "@lerna/init": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.13.1.tgz",
+      "integrity": "sha512-M59WACqim8WkH5FQEGOCEZ89NDxCKBfFTx4ZD5ig3LkGyJ8RdcJq5KEfpW/aESuRE9JrZLzVr0IjKbZSxzwEMA==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "fs-extra": "^7.0.0",
+        "p-map": "^1.2.0",
+        "write-json-file": "^2.3.0"
+      }
+    },
+    "@lerna/link": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.13.1.tgz",
+      "integrity": "sha512-N3h3Fj1dcea+1RaAoAdy4g2m3fvU7m89HoUn5X/Zcw5n2kPoK8kTO+NfhNAatfRV8VtMXst8vbNrWQQtfm0FFw==",
+      "dev": true,
+      "requires": {
+        "@lerna/command": "3.13.1",
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/symlink-dependencies": "3.13.0",
+        "p-map": "^1.2.0",
+        "slash": "^1.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/list": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.13.1.tgz",
+      "integrity": "sha512-635iRbdgd9gNvYLLIbYdQCQLr+HioM5FGJLFS0g3DPGygr6iDR8KS47hzCRGH91LU9NcM1mD1RoT/AChF+QbiA==",
+      "dev": true,
+      "requires": {
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/listable": "3.13.0",
+        "@lerna/output": "3.13.0"
+      }
+    },
+    "@lerna/listable": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.13.0.tgz",
+      "integrity": "sha512-liYJ/WBUYP4N4MnSVZuLUgfa/jy3BZ02/1Om7xUY09xGVSuNVNEeB8uZUMSC+nHqFHIsMPZ8QK9HnmZb1E/eTA==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.13.0",
+        "chalk": "^2.3.1",
+        "columnify": "^1.5.4"
+      }
+    },
+    "@lerna/log-packed": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
+      "integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
+      "dev": true,
+      "requires": {
+        "byte-size": "^4.0.3",
+        "columnify": "^1.5.4",
+        "has-unicode": "^2.0.1",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/npm-conf": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
+      "integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
+      "dev": true,
+      "requires": {
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/npm-dist-tag": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.13.0.tgz",
+      "integrity": "sha512-mcuhw34JhSRFrbPn0vedbvgBTvveG52bR2lVE3M3tfE8gmR/cKS/EJFO4AUhfRKGCTFn9rjaSEzlFGYV87pemQ==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.9.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/npm-install": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.0.tgz",
+      "integrity": "sha512-qNyfts//isYQxore6fsPorNYJmPVKZ6tOThSH97tP0aV91zGMtrYRqlAoUnDwDdAjHPYEM16hNujg2wRmsqqIw==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/get-npm-exec-opts": "3.13.0",
+        "fs-extra": "^7.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "signal-exit": "^3.0.2",
+        "write-pkg": "^3.1.0"
+      }
+    },
+    "@lerna/npm-publish": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.13.0.tgz",
+      "integrity": "sha512-y4WO0XTaf9gNRkI7as6P2ItVDOxmYHwYto357fjybcnfXgMqEA94c3GJ++jU41j0A9vnmYC6/XxpTd9sVmH9tA==",
+      "dev": true,
+      "requires": {
+        "@lerna/run-lifecycle": "3.13.0",
+        "figgy-pudding": "^3.5.1",
+        "fs-extra": "^7.0.0",
+        "libnpmpublish": "^1.1.1",
+        "npmlog": "^4.1.2",
+        "pify": "^3.0.0",
+        "read-package-json": "^2.0.13"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/npm-run-script": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.0.tgz",
+      "integrity": "sha512-hiL3/VeVp+NFatBjkGN8mUdX24EfZx9rQlSie0CMgtjc7iZrtd0jCguLomSCRHYjJuvqgbp+LLYo7nHVykfkaQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@lerna/get-npm-exec-opts": "3.13.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/output": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
+      "integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/pack-directory": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.13.1.tgz",
+      "integrity": "sha512-kXnyqrkQbCIZOf1054N88+8h0ItC7tUN5v9ca/aWpx298gsURpxUx/1TIKqijL5TOnHMyIkj0YJmnH/PyBVLKA==",
+      "dev": true,
+      "requires": {
+        "@lerna/get-packed": "3.13.0",
+        "@lerna/package": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "figgy-pudding": "^3.5.1",
+        "npm-packlist": "^1.4.1",
+        "npmlog": "^4.1.2",
+        "tar": "^4.4.8",
+        "temp-write": "^3.4.0"
+      },
+      "dependencies": {
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/package": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.13.0.tgz",
+      "integrity": "sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "write-pkg": "^3.1.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/package-graph": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.13.0.tgz",
+      "integrity": "sha512-3mRF1zuqFE1HEFmMMAIggXy+f+9cvHhW/jzaPEVyrPNLKsyfJQtpTNzeI04nfRvbAh+Gd2aNksvaW/w3xGJnnw==",
+      "dev": true,
+      "requires": {
+        "@lerna/validation-error": "3.13.0",
+        "npm-package-arg": "^6.1.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/project": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.13.1.tgz",
+      "integrity": "sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/package": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "cosmiconfig": "^5.1.0",
+        "dedent": "^0.7.0",
+        "dot-prop": "^4.2.0",
+        "glob-parent": "^3.1.0",
+        "globby": "^8.0.1",
+        "load-json-file": "^4.0.0",
+        "npmlog": "^4.1.2",
+        "p-map": "^1.2.0",
+        "resolve-from": "^4.0.0",
+        "write-json-file": "^2.3.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
+          "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+          "dev": true,
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "lodash.get": "^4.4.2",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "dev": true,
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+              "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+              "dev": true
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/prompt": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
+      "integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
+      "dev": true,
+      "requires": {
+        "inquirer": "^6.2.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/publish": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.1.tgz",
+      "integrity": "sha512-KhCJ9UDx76HWCF03i5TD7z5lX+2yklHh5SyO8eDaLptgdLDQ0Z78lfGj3JhewHU2l46FztmqxL/ss0IkWHDL+g==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/check-working-tree": "3.13.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/describe-ref": "3.13.0",
+        "@lerna/log-packed": "3.13.0",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/npm-dist-tag": "3.13.0",
+        "@lerna/npm-publish": "3.13.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/pack-directory": "3.13.1",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "@lerna/version": "3.13.1",
+        "figgy-pudding": "^3.5.1",
+        "fs-extra": "^7.0.0",
+        "libnpmaccess": "^3.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.9.0",
+        "npmlog": "^4.1.2",
+        "p-finally": "^1.0.0",
+        "p-map": "^1.2.0",
+        "p-pipe": "^1.2.0",
+        "p-reduce": "^1.0.0",
+        "pacote": "^9.5.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "@lerna/pulse-till-done": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
+      "integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/resolve-symlink": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
+      "integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "npmlog": "^4.1.2",
+        "read-cmd-shim": "^1.0.1"
+      }
+    },
+    "@lerna/rimraf-dir": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.0.tgz",
+      "integrity": "sha512-kte+pMemulre8cmPqljxIYjCmdLByz8DgHBHXB49kz2EiPf8JJ+hJFt0PzEubEyJZ2YE2EVAx5Tv5+NfGNUQyQ==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "npmlog": "^4.1.2",
+        "path-exists": "^3.0.0",
+        "rimraf": "^2.6.2"
+      }
+    },
+    "@lerna/run": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.13.1.tgz",
+      "integrity": "sha512-nv1oj7bsqppWm1M4ifN+/IIbVu9F4RixrbQD2okqDGYne4RQPAXyb5cEZuAzY/wyGTWWiVaZ1zpj5ogPWvH0bw==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/npm-run-script": "3.13.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/timer": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "p-map": "^1.2.0"
+      }
+    },
+    "@lerna/run-lifecycle": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.13.0.tgz",
+      "integrity": "sha512-oyiaL1biZdjpmjh6X/5C4w07wNFyiwXSSHH5GQB4Ay4BPwgq9oNhCcxRoi0UVZlZ1YwzSW8sTwLgj8emkIo3Yg==",
+      "dev": true,
+      "requires": {
+        "@lerna/npm-conf": "3.13.0",
+        "figgy-pudding": "^3.5.1",
+        "npm-lifecycle": "^2.1.0",
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/run-parallel-batches": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
+      "integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
+      "dev": true,
+      "requires": {
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0"
+      }
+    },
+    "@lerna/symlink-binary": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.13.0.tgz",
+      "integrity": "sha512-obc4Y6jxywkdaCe+DB0uTxYqP0IQ8mFWvN+k/YMbwH4G2h7M7lCBWgPy8e7xw/50+1II9tT2sxgx+jMus1sTJg==",
+      "dev": true,
+      "requires": {
+        "@lerna/create-symlink": "3.13.0",
+        "@lerna/package": "3.13.0",
+        "fs-extra": "^7.0.0",
+        "p-map": "^1.2.0"
+      }
+    },
+    "@lerna/symlink-dependencies": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.13.0.tgz",
+      "integrity": "sha512-7CyN5WYEPkbPLbqHBIQg/YiimBzb5cIGQB0E9IkLs3+racq2vmUNQZn38LOaazQacAA83seB+zWSxlI6H+eXSg==",
+      "dev": true,
+      "requires": {
+        "@lerna/create-symlink": "3.13.0",
+        "@lerna/resolve-symlink": "3.13.0",
+        "@lerna/symlink-binary": "3.13.0",
+        "fs-extra": "^7.0.0",
+        "p-finally": "^1.0.0",
+        "p-map": "^1.2.0",
+        "p-map-series": "^1.0.0"
+      }
+    },
+    "@lerna/timer": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
+      "integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
+      "dev": true
+    },
+    "@lerna/validation-error": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
+      "integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/version": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.13.1.tgz",
+      "integrity": "sha512-WpfKc5jZBBOJ6bFS4atPJEbHSiywQ/Gcd+vrwaEGyQHWHQZnPTvhqLuq3q9fIb9sbuhH5pSY6eehhuBrKqTnjg==",
+      "dev": true,
+      "requires": {
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/check-working-tree": "3.13.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/conventional-commits": "3.13.0",
+        "@lerna/github-client": "3.13.1",
+        "@lerna/output": "3.13.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "chalk": "^2.3.1",
+        "dedent": "^0.7.0",
+        "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
+        "p-map": "^1.2.0",
+        "p-pipe": "^1.2.0",
+        "p-reduce": "^1.0.0",
+        "p-waterfall": "^1.0.0",
+        "semver": "^5.5.0",
+        "slash": "^1.0.0",
+        "temp-write": "^3.4.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/write-log-file": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
+      "integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true
+    },
+    "@octokit/endpoint": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.2.3.tgz",
+      "integrity": "sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "3.2.0",
+        "is-plain-object": "^2.0.4",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
+      }
+    },
+    "@octokit/plugin-enterprise-rest": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz",
+      "integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==",
+      "dev": true
+    },
+    "@octokit/request": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.2.tgz",
+      "integrity": "sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^3.2.0",
+        "deprecation": "^1.0.1",
+        "is-plain-object": "^2.0.4",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^2.0.1"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.20.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.20.0.tgz",
+      "integrity": "sha512-tN5j64P6QymlMzKo94DG1LRNHCwMnLg5poZlVhsCfkHhEWKpofZ1qBDr2/0w6qDLav4EA1XXMmZdNpvGhc9BDQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "2.4.2",
+        "before-after-hook": "^1.4.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^1.0.1",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -59,123 +1075,93 @@
       "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
       "dev": true,
       "requires": {
-        "any-observable": "0.3.0"
+        "any-observable": "^0.3.0"
       }
     },
     "JSONStream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
-      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
-    "abab": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
-      "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
-    },
-    "acorn-globals": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.6.2"
-      }
     },
     "acorn-jsx": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.0.tgz",
-      "integrity": "sha512-XkB50fn0MURDyww9+UYL3c1yLbOBz0ZFvrdYlGB8l+Ije1oSC75qAqrzSPjYQbdnQUzhlUGNKuesryAv0gxZOg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
-    "add-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-      "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
-      "dev": true
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "agentkeepalive": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "dev": true,
+      "requires": {
+        "humanize-ms": "^1.2.1"
+      }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "any-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
-    },
-    "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
-      "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
-      }
-    },
-    "append-transform": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "1.0.0"
-      }
     },
     "aproba": {
       "version": "1.2.0",
@@ -189,8 +1175,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.5"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -199,7 +1185,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -220,10 +1206,10 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-equal": {
+    "array-differ": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-find-index": {
@@ -244,7 +1230,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -265,11 +1251,20 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -289,18 +1284,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
-    "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -308,9 +1291,9 @@
       "dev": true
     },
     "atob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "aws-sign2": {
@@ -320,274 +1303,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "babel-helpers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-jest": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.0.1.tgz",
-      "integrity": "sha1-u6079SP7IC2gXtCmVAtIyE7tE6Y=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "23.0.1"
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-istanbul": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-      "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "test-exclude": "4.2.1"
-      }
-    },
-    "babel-plugin-jest-hoist": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz",
-      "integrity": "sha1-6qEclkVjrqnCG+zvK994U/fzwUg=",
-      "dev": true
-    },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-preset-jest": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.0.1.tgz",
-      "integrity": "sha1-YxzFRcbPAhlDATvK8i9F2H/mIZg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-jest-hoist": "23.0.1",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
-      }
-    },
-    "babel-register": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
-        }
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "balanced-match": {
@@ -602,13 +1320,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -617,7 +1335,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -626,7 +1344,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -635,7 +1353,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -644,28 +1362,42 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
+    },
+    "before-after-hook": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+      "dev": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -673,7 +1405,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -683,16 +1415,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -701,47 +1433,21 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
     },
-    "browser-process-hrtime": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
     },
-    "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
-    "bser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true,
-      "requires": {
-        "node-int64": "0.4.0"
-      }
-    },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -750,11 +1456,62 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+      "dev": true
+    },
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
       "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true
+    },
+    "byte-size": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
+      "integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==",
+      "dev": true
+    },
+    "cacache": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.3",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -762,38 +1519,60 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
+        }
       }
     },
     "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "caller-callsite": "^2.0.0"
       }
     },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
       "dev": true
     },
     "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true,
-      "optional": true
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+      "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "4.2.0",
@@ -801,9 +1580,9 @@
       "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -814,85 +1593,33 @@
         }
       }
     },
-    "capture-exit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-      "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
-      "dev": true,
-      "requires": {
-        "rsvp": "3.6.2"
-      }
-    },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
-    },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
     "class-utils": {
@@ -901,10 +1628,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -913,7 +1640,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -924,7 +1651,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-truncate": {
@@ -934,16 +1661,22 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "slice-ansi": {
@@ -958,9 +1691,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -969,7 +1702,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -981,24 +1714,14 @@
       "dev": true
     },
     "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        }
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone": {
@@ -1013,15 +1736,9 @@
       "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1"
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "~0.5.0"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1035,14 +1752,14 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -1060,35 +1777,35 @@
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "requires": {
-        "strip-ansi": "3.0.1",
-        "wcwidth": "1.0.1"
+        "strip-ansi": "^3.0.0",
+        "wcwidth": "^1.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
-    },
-    "command-join": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/command-join/-/command-join-2.0.0.tgz",
-      "integrity": "sha1-Uui5hPSHLZUv8b3IuYOX0nxxRM8=",
-      "dev": true
     },
     "commander": {
       "version": "2.19.0",
@@ -1102,15 +1819,20 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "1.0.0",
-        "dot-prop": "3.0.0"
+        "array-ify": "^1.0.0",
+        "dot-prop": "^3.0.0"
+      },
+      "dependencies": {
+        "dot-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        }
       }
-    },
-    "compare-versions": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.2.1.tgz",
-      "integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA==",
-      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1125,14 +1847,25 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "console-control-strings": {
@@ -1147,365 +1880,170 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
-    "conventional-changelog": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
-      "integrity": "sha512-2WcSUst4Y3Z4hHvoMTWXMJr/DmgVdLiMOVY1Kak2LfFz+GIz2KDp5naqbFesYbfXPmaZ5p491dO0FWZIJoJw1Q==",
-      "dev": true,
-      "requires": {
-        "conventional-changelog-angular": "1.6.6",
-        "conventional-changelog-atom": "0.2.8",
-        "conventional-changelog-codemirror": "0.3.8",
-        "conventional-changelog-core": "2.0.11",
-        "conventional-changelog-ember": "0.3.12",
-        "conventional-changelog-eslint": "1.0.9",
-        "conventional-changelog-express": "0.3.6",
-        "conventional-changelog-jquery": "0.1.0",
-        "conventional-changelog-jscs": "0.1.0",
-        "conventional-changelog-jshint": "0.3.8",
-        "conventional-changelog-preset-loader": "1.1.8"
-      }
-    },
     "conventional-changelog-angular": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
-      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+      "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-atom": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
-      "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-cli": {
-      "version": "1.3.22",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-1.3.22.tgz",
-      "integrity": "sha512-pnjdIJbxjkZ5VdAX/H1wndr1G10CY8MuZgnXuJhIHglOXfIrXygb7KZC836GW9uo1u8PjEIvIw/bKX0lOmOzZg==",
-      "dev": true,
-      "requires": {
-        "add-stream": "1.0.0",
-        "conventional-changelog": "1.1.24",
-        "lodash": "4.17.10",
-        "meow": "4.0.1",
-        "tempfile": "1.1.1"
-      }
-    },
-    "conventional-changelog-codemirror": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
-      "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
       }
     },
     "conventional-changelog-core": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
-      "integrity": "sha512-HvTE6RlqeEZ/NFPtQeFLsIDOLrGP3bXYr7lFLMhCVsbduF1MXIe8OODkwMFyo1i9ku9NWBwVnVn0jDmIFXjDRg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz",
+      "integrity": "sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "3.0.9",
-        "conventional-commits-parser": "2.1.7",
-        "dateformat": "3.0.3",
-        "get-pkg-repo": "1.4.0",
-        "git-raw-commits": "1.3.6",
-        "git-remote-origin-url": "2.0.0",
-        "git-semver-tags": "1.3.6",
-        "lodash": "4.17.10",
-        "normalize-package-data": "2.4.0",
-        "q": "1.5.1",
-        "read-pkg": "1.1.0",
-        "read-pkg-up": "1.0.1",
-        "through2": "2.0.3"
+        "conventional-changelog-writer": "^4.0.3",
+        "conventional-commits-parser": "^3.0.1",
+        "dateformat": "^3.0.0",
+        "get-pkg-repo": "^1.0.0",
+        "git-raw-commits": "2.0.0",
+        "git-remote-origin-url": "^2.0.0",
+        "git-semver-tags": "^2.0.2",
+        "lodash": "^4.2.1",
+        "normalize-package-data": "^2.3.5",
+        "q": "^1.5.1",
+        "read-pkg": "^3.0.0",
+        "read-pkg-up": "^3.0.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "pify": "^3.0.0"
           }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         },
         "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         }
-      }
-    },
-    "conventional-changelog-ember": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
-      "integrity": "sha512-mmJzA7uzbrOqeF89dMMi6z17O07ORTXlTMArnLG9ZTX4oLaKNolUlxFUFlFm9JUoVWajVpaHQWjxH1EOQ+ARoQ==",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-eslint": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
-      "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-express": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
-      "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-jquery": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
-      "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-jscs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
-      "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
-    "conventional-changelog-jshint": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
-      "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
-      "dev": true,
-      "requires": {
-        "compare-func": "1.3.2",
-        "q": "1.5.1"
       }
     },
     "conventional-changelog-preset-loader": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz",
-      "integrity": "sha512-MkksM4G4YdrMlT2MbTsV2F6LXu/hZR0Tc/yenRrDIKRwBl/SP7ER4ZDlglqJsCzLJi4UonBc52Bkm5hzrOVCcw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz",
+      "integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ==",
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
-      "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
+      "integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
       "dev": true,
       "requires": {
-        "compare-func": "1.3.2",
-        "conventional-commits-filter": "1.1.6",
-        "dateformat": "3.0.3",
-        "handlebars": "4.0.11",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.10",
-        "meow": "4.0.1",
-        "semver": "5.5.0",
-        "split": "1.0.1",
-        "through2": "2.0.3"
+        "compare-func": "^1.3.1",
+        "conventional-commits-filter": "^2.0.1",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "semver": "^5.5.0",
+        "split": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "conventional-commits-filter": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz",
-      "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
+      "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
       "dev": true,
       "requires": {
-        "is-subset": "0.1.1",
-        "modify-values": "1.0.1"
+        "is-subset": "^0.1.1",
+        "modify-values": "^1.0.0"
       }
     },
     "conventional-commits-parser": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
-      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+      "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.4",
-        "is-text-path": "1.0.1",
-        "lodash": "4.17.10",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.3",
-        "trim-off-newlines": "1.0.1"
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
       }
     },
     "conventional-recommended-bump": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
-      "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz",
+      "integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.1",
-        "conventional-commits-filter": "1.1.6",
-        "conventional-commits-parser": "2.1.7",
-        "git-raw-commits": "1.3.6",
-        "git-semver-tags": "1.3.6",
-        "meow": "3.7.0",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        }
+        "concat-stream": "^1.6.0",
+        "conventional-changelog-preset-loader": "^2.0.2",
+        "conventional-commits-filter": "^2.0.1",
+        "conventional-commits-parser": "^3.0.1",
+        "git-raw-commits": "2.0.0",
+        "git-semver-tags": "^2.0.2",
+        "meow": "^4.0.0",
+        "q": "^1.5.1"
       }
     },
-    "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
@@ -1520,18 +2058,9 @@
       "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
       "dev": true,
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.12.0",
-        "parse-json": "4.0.0"
-      }
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "1.0.0"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0"
       }
     },
     "cross-spawn": {
@@ -1540,24 +2069,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
-    },
-    "cssstyle": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
-      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
-      "dev": true,
-      "requires": {
-        "cssom": "0.3.2"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "currently-unhandled": {
@@ -1566,8 +2080,14 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
+    },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
     },
     "dargs": {
       "version": "4.1.0",
@@ -1575,7 +2095,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "dashdash": {
@@ -1584,24 +2104,13 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "data-urls": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
-      "dev": true,
-      "requires": {
-        "abab": "1.0.4",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.1"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
     "dateformat": {
@@ -1611,13 +2120,19 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+      "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1631,8 +2146,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "1.2.0",
-        "map-obj": "1.0.1"
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "map-obj": {
@@ -1655,37 +2170,17 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "default-require-extensions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
-      }
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
+      "dev": true
     },
     "defaults": {
       "version": "1.0.3",
@@ -1693,17 +2188,16 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -1712,8 +2206,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1722,7 +2216,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1731,7 +2225,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1740,32 +2234,54 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -1780,49 +2296,72 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
+    "deprecation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+      "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
+      "dev": true
+    },
     "detect-indent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
       "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true
     },
-    "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-      "dev": true
-    },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
-    },
-    "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
-    "domexception": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       }
     },
     "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer": {
@@ -1831,20 +2370,26 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "elegant-spinner": {
@@ -1853,37 +2398,83 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-string-regexp": {
@@ -1892,209 +2483,91 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-      "dev": true,
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "eslint": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.8.0.tgz",
-      "integrity": "sha512-Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==",
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
+      "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "ajv": "6.5.5",
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "debug": "4.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "4.0.0",
-        "eslint-utils": "1.3.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "4.1.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.8.0",
-        "ignore": "4.0.6",
-        "imurmurhash": "0.1.4",
-        "inquirer": "6.2.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.1",
-        "regexpp": "2.0.1",
-        "require-uncached": "1.0.3",
-        "semver": "5.6.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "5.1.0",
-        "text-table": "0.2.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "esutils": "2.0.2",
-            "js-tokens": "4.0.0"
-          }
-        },
-        "ajv": {
-          "version": "6.5.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
-          }
-        },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-          "dev": true
-        },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.6.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
-        "external-editor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+        "doctrine": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
           "dev": true,
           "requires": {
-            "chardet": "0.7.0",
-            "iconv-lite": "0.4.24",
-            "tmp": "0.0.33"
+            "esutils": "^2.0.2"
           }
         },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": "2.1.2"
-          }
-        },
-        "inquirer": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-          "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "3.0.3",
-            "figures": "2.0.0",
-            "lodash": "4.17.10",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "6.2.0",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "regexpp": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-          "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
           "dev": true
         },
         "semver": {
@@ -2111,18 +2584,18 @@
       "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
       "dev": true,
       "requires": {
-        "eslint-restricted-globals": "0.1.1",
-        "object.assign": "4.1.0",
-        "object.entries": "1.0.4"
+        "eslint-restricted-globals": "^0.1.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
       }
     },
     "eslint-config-prettier": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz",
-      "integrity": "sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+      "integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
       "dev": true,
       "requires": {
-        "get-stdin": "5.0.1"
+        "get-stdin": "^6.0.0"
       }
     },
     "eslint-import-resolver-node": {
@@ -2131,206 +2604,75 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.8.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       }
     },
     "eslint-module-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2"
-          }
-        }
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
       }
     },
     "eslint-plugin-es": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz",
-      "integrity": "sha512-9XcVyZiQRVeFjqHw8qHNDAZcQLqaHlOGGpeYqzYh8S4JYCWTCO3yzyen8yVmA5PratfzTRWDwCOFphtDEG+w/w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
       "dev": true,
       "requires": {
-        "eslint-utils": "1.3.1",
-        "regexpp": "2.0.0"
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
       }
     },
     "eslint-plugin-import": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
-      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
+      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
       "dev": true,
       "requires": {
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.2.0",
-        "has": "1.0.3",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.8.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        }
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.3.0",
+        "has": "^1.0.3",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.9.0"
       }
     },
     "eslint-plugin-jest": {
-      "version": "21.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.22.0.tgz",
-      "integrity": "sha512-0TzGIZ5moLR9orka/J9lg+7Ezv+S0TsnkavrMmI5xPFnbyIDjc2jLlwtBsaBbdZuOSCl+kcofh9ojknTI9L32Q==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz",
+      "integrity": "sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==",
       "dev": true
     },
     "eslint-plugin-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
-      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz",
+      "integrity": "sha512-ZjOjbjEi6jd82rIpFSgagv4CHWzG9xsQAVp1ZPlhRnnYxcTgENUVBvhYmkQ7GvT1QFijUSo69RaiOJKhMu6i8w==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "1.3.1",
-        "eslint-utils": "1.3.1",
-        "ignore": "4.0.6",
-        "minimatch": "3.0.4",
-        "resolve": "1.8.1",
-        "semver": "5.5.0"
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^5.0.2",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
       }
     },
     "eslint-plugin-prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
-      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
-      },
-      "dependencies": {
-        "jest-docblock": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-          "dev": true
-        }
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-promise": {
@@ -2345,7 +2687,7 @@
       "integrity": "sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==",
       "dev": true,
       "requires": {
-        "safe-regex": "1.1.0"
+        "safe-regex": "^1.1.0"
       }
     },
     "eslint-restricted-globals": {
@@ -2355,13 +2697,13 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -2377,22 +2719,14 @@
       "dev": true
     },
     "espree": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-      "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "dev": true,
       "requires": {
-        "acorn": "6.0.4",
-        "acorn-jsx": "5.0.0",
-        "eslint-visitor-keys": "1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
-          "dev": true
-        }
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
@@ -2407,7 +2741,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -2416,7 +2750,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -2431,41 +2765,44 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "exec-sh": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-      "dev": true,
-      "requires": {
-        "merge": "1.2.0"
-      }
-    },
     "execa": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
       }
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -2473,31 +2810,22 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -2506,82 +2834,15 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
-          }
-        }
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.4"
-      },
-      "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "dev": true,
-          "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.0.0",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
-      }
-    },
-    "expect": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
-      "integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.1",
-        "jest-diff": "23.0.1",
-        "jest-get-type": "22.4.3",
-        "jest-matcher-utils": "23.0.1",
-        "jest-message-util": "23.1.0",
-        "jest-regex-util": "23.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -2590,8 +2851,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2600,20 +2861,20 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -2622,14 +2883,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -2638,7 +2899,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -2647,7 +2908,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2656,7 +2917,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2665,7 +2926,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2674,16 +2935,10 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -2694,16 +2949,41 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+      "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -2717,14 +2997,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fb-watchman": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true,
-      "requires": {
-        "bser": "2.0.0"
-      }
+    "figgy-pudding": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "dev": true
     },
     "figures": {
       "version": "2.0.0",
@@ -2732,33 +3009,16 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      }
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-      "dev": true
-    },
-    "fileset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "flat-cache": "^2.0.1"
       }
     },
     "fill-range": {
@@ -2767,10 +3027,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2779,7 +3039,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2796,40 +3056,46 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      }
+    },
+    "fn-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {
@@ -2839,14 +3105,14 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -2855,18 +3121,60 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -2875,533 +3183,16 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        }
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "function-bind": {
@@ -3416,29 +3207,46 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "g-status": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/g-status/-/g-status-2.0.2.tgz",
+      "integrity": "sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "matcher": "^1.0.0",
+        "simple-git": "^1.85.0"
+      }
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -3447,9 +3255,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -3458,15 +3266,21 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
     },
+    "genfun": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+      "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+      "dev": true
+    },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-own-enumerable-property-symbols": {
@@ -3481,11 +3295,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "meow": "3.7.0",
-        "normalize-package-data": "2.4.0",
-        "parse-github-repo-url": "1.4.1",
-        "through2": "2.0.3"
+        "hosted-git-info": "^2.1.4",
+        "meow": "^3.3.0",
+        "normalize-package-data": "^2.3.0",
+        "parse-github-repo-url": "^1.3.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -3500,8 +3314,18 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "get-stdin": {
@@ -3516,7 +3340,20 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "map-obj": {
@@ -3531,16 +3368,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "minimist": {
@@ -3549,14 +3386,73 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
         "redent": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -3565,7 +3461,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "trim-newlines": {
@@ -3583,9 +3479,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -3606,20 +3502,20 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "git-raw-commits": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
-      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
+      "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
       "dev": true,
       "requires": {
-        "dargs": "4.1.0",
-        "lodash.template": "4.4.0",
-        "meow": "4.0.1",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
       }
     },
     "git-remote-origin-url": {
@@ -3628,18 +3524,37 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "1.0.0",
-        "pify": "2.3.0"
+        "gitconfiglocal": "^1.0.0",
+        "pify": "^2.3.0"
       }
     },
     "git-semver-tags": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
-      "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
+      "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
       "dev": true,
       "requires": {
-        "meow": "4.0.1",
-        "semver": "5.5.0"
+        "meow": "^4.0.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "git-up": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^5.0.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "dev": true,
+      "requires": {
+        "git-up": "^4.0.0"
       }
     },
     "gitconfiglocal": {
@@ -3648,57 +3563,21 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.2"
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "2.0.1"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -3707,71 +3586,73 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       }
     },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+      "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
-    "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "array-union": "^1.0.1",
+        "dir-glob": "2.0.0",
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "growly": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
       }
     },
     "har-schema": {
@@ -3781,13 +3662,13 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -3796,7 +3677,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -3805,7 +3686,15 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -3832,9 +3721,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -3843,8 +3732,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3853,19 +3742,9 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "home-or-tmp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
       }
     },
     "hosted-git-info": {
@@ -3874,13 +3753,31 @@
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
     },
-    "html-encoding-sniffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.3"
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "http-signature": {
@@ -3889,9 +3786,45 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
       }
     },
     "husky": {
@@ -3900,16 +3833,16 @@
       "integrity": "sha512-6uc48B/A2Mqi65yeg37d/TPcTb0bZ1GTkMYOM0nXLOPuPaTRhXCeee80/noOrbavWd12x72Tusja7GJ5rzvV6g==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "5.0.6",
-        "execa": "0.9.0",
-        "find-up": "3.0.0",
-        "get-stdin": "6.0.0",
-        "is-ci": "1.2.1",
-        "pkg-dir": "3.0.0",
-        "please-upgrade-node": "3.1.1",
-        "read-pkg": "4.0.1",
-        "run-node": "1.0.0",
-        "slash": "2.0.0"
+        "cosmiconfig": "^5.0.6",
+        "execa": "^0.9.0",
+        "find-up": "^3.0.0",
+        "get-stdin": "^6.0.0",
+        "is-ci": "^1.2.1",
+        "pkg-dir": "^3.0.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^4.0.1",
+        "run-node": "^1.0.0",
+        "slash": "^2.0.0"
       },
       "dependencies": {
         "ci-info": {
@@ -3924,13 +3857,13 @@
           "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "find-up": {
@@ -3939,7 +3872,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-stdin": {
@@ -3954,7 +3887,7 @@
           "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
-            "ci-info": "1.6.0"
+            "ci-info": "^1.5.0"
           }
         },
         "locate-path": {
@@ -3963,8 +3896,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -3973,7 +3906,7 @@
           "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
           "dev": true,
           "requires": {
-            "p-try": "2.0.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -3982,7 +3915,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.0.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -4003,7 +3936,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "3.0.0"
+            "find-up": "^3.0.0"
           }
         },
         "read-pkg": {
@@ -4012,9 +3945,9 @@
           "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
           "dev": true,
           "requires": {
-            "normalize-package-data": "2.4.0",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0"
+            "normalize-package-data": "^2.3.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0"
           }
         },
         "slash": {
@@ -4026,28 +3959,43 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
-    "import-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+    "ignore": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
+      "integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
+      "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "minimatch": "^3.0.4"
+      }
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       }
     },
     "imurmurhash": {
@@ -4068,8 +4016,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -4084,41 +4032,70 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+    "init-package-json": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+      "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "glob": "^7.1.1",
+        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "promzard": "^0.3.0",
+        "read": "~1.0.1",
+        "read-package-json": "1 || 2",
+        "semver": "2.x || 3.x || 4 || 5",
+        "validate-npm-package-license": "^3.0.1",
+        "validate-npm-package-name": "^3.0.0"
       }
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+    "inquirer": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -4127,7 +4104,18 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -4148,23 +4136,14 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
-    },
-    "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "1.1.3"
-      }
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -4172,7 +4151,18 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-date-object": {
@@ -4187,9 +4177,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4205,21 +4195,6 @@
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "dev": true
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -4239,7 +4214,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4248,19 +4223,13 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
-    "is-generator-fn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
-      "dev": true
-    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.0"
       }
     },
     "is-number": {
@@ -4269,7 +4238,18 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "is-obj": {
@@ -4284,24 +4264,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.2.0"
-      }
-    },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
+        "symbol-observable": "^1.1.0"
       }
     },
     "is-path-cwd": {
@@ -4316,7 +4279,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -4325,7 +4288,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -4340,31 +4303,13 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "dev": true
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
@@ -4373,7 +4318,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-regexp": {
@@ -4382,17 +4327,14 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
+    "is-ssh": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "dev": true,
+      "requires": {
+        "protocols": "^1.1.0"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4407,10 +4349,13 @@
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-text-path": {
       "version": "1.0.1",
@@ -4418,7 +4363,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "1.7.0"
+        "text-extensions": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -4463,947 +4408,10 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "istanbul-api": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-      "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
-      "dev": true,
-      "requires": {
-        "async": "2.6.1",
-        "compare-versions": "3.2.1",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.2.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.4",
-        "istanbul-lib-source-maps": "1.2.5",
-        "istanbul-reports": "1.3.0",
-        "js-yaml": "3.12.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.10"
-          }
-        }
-      }
-    },
-    "istanbul-lib-coverage": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-      "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
-      "dev": true
-    },
-    "istanbul-lib-hook": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.0.tgz",
-      "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
-      "dev": true,
-      "requires": {
-        "append-transform": "0.4.0"
-      }
-    },
-    "istanbul-lib-instrument": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-      "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
-      "dev": true,
-      "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "semver": "5.5.0"
-      }
-    },
-    "istanbul-lib-report": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-      "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-      "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "istanbul-reports": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-      "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
-      "dev": true,
-      "requires": {
-        "handlebars": "4.0.11"
-      }
-    },
-    "jest": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-23.1.0.tgz",
-      "integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
-      "dev": true,
-      "requires": {
-        "import-local": "1.0.0",
-        "jest-cli": "23.1.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "jest-cli": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.1.0.tgz",
-          "integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "exit": "0.1.2",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "import-local": "1.0.0",
-            "is-ci": "1.1.0",
-            "istanbul-api": "1.3.1",
-            "istanbul-lib-coverage": "1.2.0",
-            "istanbul-lib-instrument": "1.10.1",
-            "istanbul-lib-source-maps": "1.2.5",
-            "jest-changed-files": "23.0.1",
-            "jest-config": "23.1.0",
-            "jest-environment-jsdom": "23.1.0",
-            "jest-get-type": "22.4.3",
-            "jest-haste-map": "23.1.0",
-            "jest-message-util": "23.1.0",
-            "jest-regex-util": "23.0.0",
-            "jest-resolve-dependencies": "23.0.1",
-            "jest-runner": "23.1.0",
-            "jest-runtime": "23.1.0",
-            "jest-snapshot": "23.0.1",
-            "jest-util": "23.1.0",
-            "jest-validate": "23.0.1",
-            "jest-watcher": "23.1.0",
-            "jest-worker": "23.0.1",
-            "micromatch": "2.3.11",
-            "node-notifier": "5.2.1",
-            "realpath-native": "1.0.0",
-            "rimraf": "2.6.2",
-            "slash": "1.0.0",
-            "string-length": "2.0.0",
-            "strip-ansi": "4.0.0",
-            "which": "1.3.0",
-            "yargs": "11.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        },
-        "yargs": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
-    "jest-changed-files": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.0.1.tgz",
-      "integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
-      "dev": true,
-      "requires": {
-        "throat": "4.1.0"
-      }
-    },
-    "jest-config": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
-      "integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.3",
-        "babel-jest": "23.0.1",
-        "chalk": "2.4.1",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "23.1.0",
-        "jest-environment-node": "23.1.0",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "23.1.0",
-        "jest-regex-util": "23.0.0",
-        "jest-resolve": "23.1.0",
-        "jest-util": "23.1.0",
-        "jest-validate": "23.0.1",
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-diff": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
-      "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-docblock": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
-      "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
-      "dev": true,
-      "requires": {
-        "detect-newline": "2.1.0"
-      }
-    },
-    "jest-each": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.1.0.tgz",
-      "integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-environment-jsdom": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
-      "integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
-      "dev": true,
-      "requires": {
-        "jest-mock": "23.1.0",
-        "jest-util": "23.1.0",
-        "jsdom": "11.11.0"
-      }
-    },
-    "jest-environment-node": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
-      "integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
-      "dev": true,
-      "requires": {
-        "jest-mock": "23.1.0",
-        "jest-util": "23.1.0"
-      }
-    },
-    "jest-get-type": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
-      "dev": true
-    },
-    "jest-haste-map": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.1.0.tgz",
-      "integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
-      "dev": true,
-      "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "23.0.1",
-        "jest-serializer": "23.0.1",
-        "jest-worker": "23.0.1",
-        "micromatch": "2.3.11",
-        "sane": "2.5.2"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        }
-      }
-    },
-    "jest-in-case": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jest-in-case/-/jest-in-case-1.0.2.tgz",
-      "integrity": "sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=",
-      "dev": true
-    },
-    "jest-jasmine2": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
-      "integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "co": "4.6.0",
-        "expect": "23.1.0",
-        "is-generator-fn": "1.0.0",
-        "jest-diff": "23.0.1",
-        "jest-each": "23.1.0",
-        "jest-matcher-utils": "23.0.1",
-        "jest-message-util": "23.1.0",
-        "jest-snapshot": "23.0.1",
-        "jest-util": "23.1.0",
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-leak-detector": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz",
-      "integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
-      "dev": true,
-      "requires": {
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
-      "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-message-util": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
-      "integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "chalk": "2.4.1",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0",
-        "stack-utils": "1.0.1"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        }
-      }
-    },
-    "jest-mock": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
-      "integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
-      "dev": true
-    },
-    "jest-regex-util": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-      "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-      "dev": true
-    },
-    "jest-resolve": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
-      "integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
-      "dev": true,
-      "requires": {
-        "browser-resolve": "1.11.2",
-        "chalk": "2.4.1",
-        "realpath-native": "1.0.0"
-      }
-    },
-    "jest-resolve-dependencies": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz",
-      "integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
-      "dev": true,
-      "requires": {
-        "jest-regex-util": "23.0.0",
-        "jest-snapshot": "23.0.1"
-      }
-    },
-    "jest-runner": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.1.0.tgz",
-      "integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
-      "dev": true,
-      "requires": {
-        "exit": "0.1.2",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.1.0",
-        "jest-docblock": "23.0.1",
-        "jest-haste-map": "23.1.0",
-        "jest-jasmine2": "23.1.0",
-        "jest-leak-detector": "23.0.1",
-        "jest-message-util": "23.1.0",
-        "jest-runtime": "23.1.0",
-        "jest-util": "23.1.0",
-        "jest-worker": "23.0.1",
-        "source-map-support": "0.5.6",
-        "throat": "4.1.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "1.1.0",
-            "source-map": "0.6.1"
-          }
-        }
-      }
-    },
-    "jest-runtime": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.1.0.tgz",
-      "integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.3",
-        "babel-plugin-istanbul": "4.1.6",
-        "chalk": "2.4.1",
-        "convert-source-map": "1.5.1",
-        "exit": "0.1.2",
-        "fast-json-stable-stringify": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.1.0",
-        "jest-haste-map": "23.1.0",
-        "jest-message-util": "23.1.0",
-        "jest-regex-util": "23.0.0",
-        "jest-resolve": "23.1.0",
-        "jest-snapshot": "23.0.1",
-        "jest-util": "23.1.0",
-        "jest-validate": "23.0.1",
-        "micromatch": "2.3.11",
-        "realpath-native": "1.0.0",
-        "slash": "1.0.0",
-        "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "11.0.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-          "dev": true
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        },
-        "yargs": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
-    "jest-serializer": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-      "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
-      "dev": true
-    },
-    "jest-snapshot": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
-      "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "jest-diff": "23.0.1",
-        "jest-matcher-utils": "23.0.1",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-util": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
-      "integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
-      "dev": true,
-      "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.4.1",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.1.0",
-        "jest-message-util": "23.1.0",
-        "mkdirp": "0.5.1",
-        "slash": "1.0.0",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "jest-validate": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.0.1.tgz",
-      "integrity": "sha1-zZ8BqJ0mu4hfEqhmdxXpyGWldU8=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "jest-get-type": "22.4.3",
-        "leven": "2.1.0",
-        "pretty-format": "23.0.1"
-      }
-    },
-    "jest-watcher": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.1.0.tgz",
-      "integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "string-length": "2.0.0"
-      }
-    },
-    "jest-worker": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
-      "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
-      "dev": true,
-      "requires": {
-        "merge-stream": "1.0.1"
-      }
-    },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -5412,55 +4420,14 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
-    "jsdom": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
-      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
-      "dev": true,
-      "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.6.2",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.2",
-        "cssstyle": "0.3.1",
-        "data-urls": "1.0.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.9.1",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwsapi": "2.0.1",
-        "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.87.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.4.2",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.1",
-        "ws": "4.1.0",
-        "xml-name-validator": "3.0.0"
-      }
-    },
-    "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -5476,9 +4443,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
@@ -5492,21 +4459,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
-    },
-    "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -5527,103 +4479,56 @@
       }
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
-    },
-    "left-pad": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
-    "lerna": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-2.11.0.tgz",
-      "integrity": "sha512-kgM6zwe2P2tR30MYvgiLLW+9buFCm6E7o8HnRlhTgm70WVBvXVhydqv+q/MF2HrVZkCawfVtCfetyQmtd4oHhQ==",
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "chalk": "2.4.1",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "command-join": "2.0.0",
-        "conventional-changelog-cli": "1.3.22",
-        "conventional-recommended-bump": "1.2.1",
-        "dedent": "0.7.0",
-        "execa": "0.8.0",
-        "find-up": "2.1.0",
-        "fs-extra": "4.0.3",
-        "get-port": "3.2.0",
-        "glob": "7.1.2",
-        "glob-parent": "3.1.0",
-        "globby": "6.1.0",
-        "graceful-fs": "4.1.11",
-        "hosted-git-info": "2.6.0",
-        "inquirer": "3.3.0",
-        "is-ci": "1.1.0",
-        "load-json-file": "4.0.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "npmlog": "4.1.2",
-        "p-finally": "1.0.0",
-        "package-json": "4.0.1",
-        "path-exists": "3.0.0",
-        "read-cmd-shim": "1.0.1",
-        "read-pkg": "3.0.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
-        "semver": "5.5.0",
-        "signal-exit": "3.0.2",
-        "slash": "1.0.0",
-        "strong-log-transformer": "1.0.6",
-        "temp-write": "3.4.0",
-        "write-file-atomic": "2.3.0",
-        "write-json-file": "2.3.0",
-        "write-pkg": "3.2.0",
-        "yargs": "8.0.2"
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "lerna": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.13.1.tgz",
+      "integrity": "sha512-7kSz8LLozVsoUNTJzJzy+b8TnV9YdviR2Ee2PwGZSlVw3T1Rn7kOAPZjEi+3IWnOPC96zMPHVmjCmzQ4uubalw==",
+      "dev": true,
+      "requires": {
+        "@lerna/add": "3.13.1",
+        "@lerna/bootstrap": "3.13.1",
+        "@lerna/changed": "3.13.1",
+        "@lerna/clean": "3.13.1",
+        "@lerna/cli": "3.13.0",
+        "@lerna/create": "3.13.1",
+        "@lerna/diff": "3.13.1",
+        "@lerna/exec": "3.13.1",
+        "@lerna/import": "3.13.1",
+        "@lerna/init": "3.13.1",
+        "@lerna/link": "3.13.1",
+        "@lerna/list": "3.13.1",
+        "@lerna/publish": "3.13.1",
+        "@lerna/run": "3.13.1",
+        "@lerna/version": "3.13.1",
+        "import-local": "^1.0.0",
+        "npmlog": "^4.1.2"
       },
       "dependencies": {
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+        "import-local": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+          "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "pkg-dir": "^2.0.0",
+            "resolve-cwd": "^2.0.0"
           }
         }
       }
-    },
-    "leven": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -5631,68 +4536,119 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "libnpmaccess": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz",
+      "integrity": "sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "get-stream": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmpublish": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.1.tgz",
+      "integrity": "sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0",
+        "semver": "^5.5.1",
+        "ssri": "^6.0.1"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        }
       }
     },
     "lint-staged": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.3.0.tgz",
-      "integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.5.tgz",
+      "integrity": "sha512-e5ZavfnSLcBJE1BTzRTqw6ly8OkqVyO3GL2M6teSmTBYQ/2BuueD5GIt2RPsP31u/vjKdexUyDCxSyK75q4BDA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "commander": "2.19.0",
-        "cosmiconfig": "5.0.6",
-        "debug": "3.1.0",
-        "dedent": "0.7.0",
-        "execa": "0.9.0",
-        "find-parent-dir": "0.3.0",
-        "is-glob": "4.0.0",
-        "is-windows": "1.0.2",
-        "jest-validate": "23.6.0",
-        "listr": "0.14.2",
-        "lodash": "4.17.10",
-        "log-symbols": "2.2.0",
-        "micromatch": "3.1.10",
-        "npm-which": "3.0.1",
-        "p-map": "1.2.0",
-        "path-is-inside": "1.0.2",
-        "pify": "3.0.0",
-        "please-upgrade-node": "3.1.1",
-        "staged-git-files": "1.1.1",
-        "string-argv": "0.0.2",
-        "stringify-object": "3.3.0"
+        "chalk": "^2.3.1",
+        "commander": "^2.14.1",
+        "cosmiconfig": "^5.0.2",
+        "debug": "^3.1.0",
+        "dedent": "^0.7.0",
+        "del": "^3.0.0",
+        "execa": "^1.0.0",
+        "find-parent-dir": "^0.3.0",
+        "g-status": "^2.0.2",
+        "is-glob": "^4.0.0",
+        "is-windows": "^1.0.2",
+        "listr": "^0.14.2",
+        "listr-update-renderer": "^0.5.0",
+        "lodash": "^4.17.11",
+        "log-symbols": "^2.2.0",
+        "micromatch": "^3.1.8",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "path-is-inside": "^1.0.2",
+        "pify": "^3.0.0",
+        "please-upgrade-node": "^3.0.2",
+        "staged-git-files": "1.1.2",
+        "string-argv": "^0.0.2",
+        "stringify-object": "^3.2.2",
+        "yup": "^0.26.10"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "execa": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
-          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "ms": "^2.1.1"
           }
         },
         "is-glob": {
@@ -5701,54 +4657,46 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
-        "jest-validate": {
-          "version": "23.6.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-          "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "jest-get-type": "22.4.3",
-            "leven": "2.1.0",
-            "pretty-format": "23.6.0"
-          }
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
-        },
-        "pretty-format": {
-          "version": "23.6.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-          "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.1"
-          }
         }
       }
     },
     "listr": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.2.tgz",
-      "integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
       "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "0.3.0",
-        "is-observable": "1.1.0",
-        "is-promise": "2.1.0",
-        "is-stream": "1.1.0",
-        "listr-silent-renderer": "1.1.1",
-        "listr-update-renderer": "0.4.0",
-        "listr-verbose-renderer": "0.4.1",
-        "p-map": "1.2.0",
-        "rxjs": "6.2.0"
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
+          "integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
+          "dev": true
+        }
       }
     },
     "listr-silent-renderer": {
@@ -5758,32 +4706,44 @@
       "dev": true
     },
     "listr-update-renderer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
-      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-truncate": "0.2.1",
-        "elegant-spinner": "1.0.1",
-        "figures": "1.7.0",
-        "indent-string": "3.2.0",
-        "log-symbols": "1.0.2",
-        "log-update": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "figures": {
@@ -5792,8 +4752,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "log-symbols": {
@@ -5802,7 +4762,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "strip-ansi": {
@@ -5811,99 +4771,49 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
     "listr-verbose-renderer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "date-fns": "1.29.0",
-        "figures": "1.7.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
       }
     },
     "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
         }
       }
     },
@@ -5913,20 +4823,38 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "lodash.sortby": {
@@ -5941,8 +4869,8 @@
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -5951,8 +4879,14 @@
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -5960,65 +4894,30 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^3.0.0",
+        "cli-cursor": "^2.0.0",
+        "wrap-ansi": "^3.0.1"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
-        "cli-cursor": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
-          }
-        },
-        "onetime": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-          "dev": true,
-          "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
           }
         }
-      }
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
-      "requires": {
-        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -6027,15 +4926,9 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
     },
     "lru-cache": {
       "version": "4.1.2",
@@ -6043,9 +4936,15 @@
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
+    },
+    "macos-release": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.1.0.tgz",
+      "integrity": "sha512-8TCbwvN1mfNxbBv0yBtfyIFMo3m1QsNbKHv7PYIp/abRBKVQBXN7ecu3aeGGgT18VC/Tf397LBDGZF9KBGJFFw==",
+      "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
@@ -6053,7 +4952,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6064,13 +4963,32 @@
         }
       }
     },
-    "makeerror": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+    "make-fetch-happen": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
+      "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "agentkeepalive": "^3.4.1",
+        "cacache": "^11.0.1",
+        "http-cache-semantics": "^3.8.1",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "node-fetch-npm": "^2.0.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^6.0.0"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -6091,22 +5009,35 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
-    "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
-      "dev": true
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+    "matcher": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.1.tgz",
+      "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "escape-string-regexp": "^1.0.4"
+      }
+    },
+    "mem": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+      "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+          "dev": true
+        }
       }
     },
     "meow": {
@@ -6115,22 +5046,60 @@
       "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
       "dev": true,
       "requires": {
-        "camelcase-keys": "4.2.0",
-        "decamelize-keys": "1.1.0",
-        "loud-rejection": "1.6.0",
-        "minimist": "1.2.0",
-        "minimist-options": "3.0.2",
-        "normalize-package-data": "2.4.0",
-        "read-pkg-up": "3.0.0",
-        "redent": "2.0.0",
-        "trim-newlines": "2.0.0"
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist": "^1.1.3",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0"
       },
       "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
         },
         "read-pkg-up": {
           "version": "3.0.0",
@@ -6138,26 +5107,17 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         }
       }
     },
-    "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+    "merge2": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
       "dev": true
-    },
-    "merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.5"
-      }
     },
     "micromatch": {
       "version": "3.1.10",
@@ -6165,42 +5125,34 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.38.0"
       }
     },
     "mimic-fn": {
@@ -6215,7 +5167,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -6230,8 +5182,53 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "is-plain-obj": "1.1.0"
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
+    "mississippi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -6240,8 +5237,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -6250,7 +5247,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -6270,11 +5267,19 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-      "dev": true
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -6282,45 +5287,41 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
+      }
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
-      "optional": true
-    },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "natural-compare": {
@@ -6329,28 +5330,70 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
       "dev": true
     },
-    "node-notifier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+    "node-fetch-npm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.5.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "encoding": "^0.1.11",
+        "json-parse-better-errors": "^1.0.0",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "dev": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -6359,19 +5402,71 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+    "normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "dev": true
+    },
+    "npm-bundled": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+      "dev": true
+    },
+    "npm-lifecycle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz",
+      "integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "byline": "^5.0.0",
+        "graceful-fs": "^4.1.11",
+        "node-gyp": "^3.8.0",
+        "resolve-from": "^4.0.0",
+        "slide": "^1.1.6",
+        "uid-number": "0.0.6",
+        "umask": "^1.1.0",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "npm-package-arg": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+      "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.6.0",
+        "osenv": "^0.1.5",
+        "semver": "^5.5.0",
+        "validate-npm-package-name": "^3.0.0"
+      }
+    },
+    "npm-packlist": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "dev": true,
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
       }
     },
     "npm-path": {
@@ -6380,7 +5475,44 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
-        "which": "1.3.0"
+        "which": "^1.2.10"
+      }
+    },
+    "npm-pick-manifest": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
+      "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.0.0",
+        "semver": "^5.4.1"
+      }
+    },
+    "npm-registry-fetch": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz",
+      "integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.3.4",
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.4.1",
+        "lru-cache": "^4.1.3",
+        "make-fetch-happen": "^4.0.1",
+        "npm-package-arg": "^6.1.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -6389,7 +5521,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npm-which": {
@@ -6398,9 +5530,9 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "2.19.0",
-        "npm-path": "2.0.4",
-        "which": "1.3.0"
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "npmlog": {
@@ -6409,10 +5541,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -6421,16 +5553,10 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "nwsapi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.1.tgz",
-      "integrity": "sha512-xOJJb7kAAGy6UOklbaIPA0iu/27VMHfAbMUgYJlXz4qRXytIkPGM2vwfbxa+tbaqcqHNsP6RN4eDZlePelWKpQ==",
-      "dev": true
-    },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
@@ -6445,9 +5571,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -6456,15 +5582,24 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
           }
         }
       }
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
       "dev": true
     },
     "object-visit": {
@@ -6473,7 +5608,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.assign": {
@@ -6482,42 +5617,22 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.entries": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0"
-      }
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "object.pick": {
@@ -6526,8 +5641,14 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
+    },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -6535,7 +5656,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -6544,7 +5665,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -6553,8 +5674,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -6571,12 +5692,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -6586,31 +5707,24 @@
       "dev": true
     },
     "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        }
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "os-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "dev": true,
+      "requires": {
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
       }
     },
     "os-tmpdir": {
@@ -6619,19 +5733,41 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
+    "p-is-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+      "dev": true
+    },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -6640,7 +5776,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -6649,22 +5785,151 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "p-map-series": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+      "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
+    },
+    "p-pipe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+      "integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
+      "dev": true
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
-    "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+    "p-waterfall": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-waterfall/-/p-waterfall-1.0.0.tgz",
+      "integrity": "sha1-ftlLPOszMngjU69qrhGqn8I1uwA=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.0"
+        "p-reduce": "^1.0.0"
+      }
+    },
+    "pacote": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.0.tgz",
+      "integrity": "sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.3",
+        "cacache": "^11.3.2",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.1.0",
+        "glob": "^7.1.3",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^4.0.1",
+        "minimatch": "^3.0.4",
+        "minipass": "^2.3.5",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.12",
+        "npm-pick-manifest": "^2.2.3",
+        "npm-registry-fetch": "^3.8.0",
+        "osenv": "^0.1.5",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^1.1.1",
+        "protoduck": "^5.0.1",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.8",
+        "unique-filename": "^1.1.1",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
       }
     },
     "parse-github-repo-url": {
@@ -6673,50 +5938,37 @@
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
       "dev": true
     },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        }
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.2"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
-    "parse5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
-      "dev": true
+    "parse-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "parse-url": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "normalize-url": "^3.3.0",
+        "parse-path": "^4.0.0",
+        "protocols": "^1.4.0"
+      }
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -6755,26 +6007,18 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
+        "pify": "^2.0.0"
       }
     },
     "performance-now": {
@@ -6801,7 +6045,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -6810,7 +6054,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "please-upgrade-node": {
@@ -6819,20 +6063,8 @@
       "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
       "dev": true,
       "requires": {
-        "semver-compare": "1.0.0"
+        "semver-compare": "^1.0.0"
       }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
-    "pn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -6846,56 +6078,20 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-      "dev": true
-    },
     "prettier": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.4.tgz",
-      "integrity": "sha512-emsEZ2bAigL1lq6ssgkpPm1MIBqgeTvcp90NxOP5XDqprub/V/WS2Hfgih3mS7/1dqTUvhG+sxx1Dv8crnVexA==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
       "dev": true
     },
-    "pretty-format": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-      "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        }
+        "fast-diff": "^1.1.2"
       }
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -6904,10 +6100,62 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "dev": true,
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      }
+    },
+    "promzard": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+      "dev": true,
+      "requires": {
+        "read": "1"
+      }
+    },
+    "property-expr": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
+      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==",
+      "dev": true
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
+    "protocols": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+      "dev": true
+    },
+    "protoduck": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+      "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+      "dev": true,
+      "requires": {
+        "genfun": "^5.0.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -6916,10 +6164,43 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.27.tgz",
-      "integrity": "sha512-J8tJX5tAeEp9tQTI2w2aMZ6V1INuU4JmNaNPRuHAqjjVq3ZJ+jV3+tcT3ncgTnBxvwJy740IB/WZrxFus2VdMA==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -6945,49 +6226,13 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
-    "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
+        "mute-stream": "~0.0.4"
       }
     },
     "read-cmd-shim": {
@@ -6996,126 +6241,89 @@
       "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.2"
       }
     },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+    "read-package-json": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+      "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
       "dev": true,
       "requires": {
-        "load-json-file": "4.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "json-parse-better-errors": "^1.0.1",
+        "normalize-package-data": "^2.0.0",
+        "slash": "^1.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
         }
       }
     },
-    "readable-stream": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+    "read-package-tree": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
+      "integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "once": "^1.3.0",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0"
       }
     },
-    "realpath-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
-      "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "util.promisify": "1.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdir-scoped-modules": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+      "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "redent": {
@@ -7124,24 +6332,15 @@
       "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
       "dev": true,
       "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
       "dev": true
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7149,45 +6348,20 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
-      "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
-      "dev": true
-    },
-    "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.8"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
       "dev": true
     },
     "repeat-string": {
@@ -7202,35 +6376,35 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
-      "version": "2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "punycode": {
@@ -7240,40 +6414,15 @@
           "dev": true
         },
         "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-          "dev": true
         }
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.10"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "dev": true,
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.4.2"
       }
     },
     "require-directory": {
@@ -7288,23 +6437,13 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
-    },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -7313,7 +6452,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -7325,9 +6464,9 @@
       }
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "resolve-url": {
@@ -7342,8 +6481,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -7352,30 +6491,20 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.1.3"
       }
-    },
-    "rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true
     },
     "run-async": {
       "version": "2.3.0",
@@ -7383,7 +6512,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-node": {
@@ -7392,34 +6521,28 @@
       "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
       "dev": true
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "aproba": "^1.1.1"
       }
     },
     "rxjs": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.0.tgz",
-      "integrity": "sha512-qBzf5uu6eOKiCZuAE0SgZ0/Qp+l54oeVxFfC2t+mJ2SFI6IB8gmMdJHs5DUMu5kqifqcCtsKS2XHjhZu6RKvAw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.2"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safe-regex": {
@@ -7428,44 +6551,13 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
-    },
-    "sane": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-      "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
-      "dev": true,
-      "requires": {
-        "anymatch": "2.0.0",
-        "capture-exit": "1.2.0",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "semver": {
@@ -7492,10 +6584,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7504,7 +6596,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7515,7 +6607,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -7524,32 +6616,60 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
-    "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+    "simple-git": {
+      "version": "1.107.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.107.0.tgz",
+      "integrity": "sha512-t4OK1JRlp4ayKRfcW6owrWcRVLyHRUlhGd0uN6ZZTqfDq8a5XpcUdOKiGRNobHEuMtNqzp0vcJNvhYWwh5PsQA==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "debug": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "smart-buffer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7557,32 +6677,23 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -7591,7 +6702,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "source-map": {
@@ -7608,9 +6719,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -7619,7 +6730,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -7628,7 +6739,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -7637,7 +6748,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -7646,16 +6757,10 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
-        },
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
         }
       }
     },
@@ -7665,7 +6770,38 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "socks": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+      "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "4.0.2"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
       }
     },
     "sort-keys": {
@@ -7674,17 +6810,14 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true,
-      "requires": {
-        "amdefine": "1.0.1"
-      }
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -7692,28 +6825,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-url": {
@@ -7728,8 +6844,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7744,8 +6860,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7760,7 +6876,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-string": {
@@ -7769,7 +6885,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "split2": {
@@ -7778,7 +6894,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -7788,32 +6904,35 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
-    "stack-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
-      "dev": true
+    "ssri": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1"
+      }
     },
     "staged-git-files": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
-      "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.2.tgz",
+      "integrity": "sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==",
       "dev": true
     },
     "static-extend": {
@@ -7822,8 +6941,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7832,15 +6951,25 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
     },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "string-argv": {
@@ -7849,33 +6978,23 @@
       "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
       "dev": true
     },
-    "string-length": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-      "dev": true,
-      "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-object": {
@@ -7884,9 +7003,9 @@
       "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "3.0.0",
-        "is-obj": "1.0.1",
-        "is-regexp": "1.0.0"
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -7895,15 +7014,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        }
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -7931,31 +7042,32 @@
       "dev": true
     },
     "strong-log-transformer": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz",
-      "integrity": "sha1-9/uTdYpppXEUAYEnfuoMLrEwH6M=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
+      "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
       "dev": true,
       "requires": {
-        "byline": "5.0.0",
-        "duplexer": "0.1.1",
-        "minimist": "0.1.0",
-        "moment": "2.22.2",
-        "through": "2.3.8"
+        "duplexer": "^0.1.1",
+        "minimist": "^1.2.0",
+        "through": "^2.3.4"
       },
       "dependencies": {
         "minimist": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-          "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "symbol-observable": {
       "version": "1.2.0",
@@ -7963,48 +7075,61 @@
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
     },
-    "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+    "synchronous-promise": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.6.tgz",
+      "integrity": "sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==",
       "dev": true
     },
     "table": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.1.0.tgz",
-      "integrity": "sha512-e542in22ZLhD/fOIuXs/8yDZ9W61ltF8daM88rkRNtgTIct+vI2fTnAyu/Db2TCfEcI8i7mjZz6meLq0nW7TYg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.5",
-        "lodash": "4.17.10",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.5.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
+      }
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "temp-dir": {
@@ -8019,12 +7144,12 @@
       "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "is-stream": "1.1.0",
-        "make-dir": "1.3.0",
-        "pify": "3.0.0",
-        "temp-dir": "1.0.0",
-        "uuid": "3.3.2"
+        "graceful-fs": "^4.1.2",
+        "is-stream": "^1.1.0",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "temp-dir": "^1.0.0",
+        "uuid": "^3.0.1"
       },
       "dependencies": {
         "pify": {
@@ -8032,54 +7157,19 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
         }
       }
     },
-    "tempfile": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2",
-        "uuid": "2.0.3"
-      }
-    },
-    "test-exclude": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-      "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "3.1.10",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
-      }
-    },
     "text-extensions": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
-      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "throat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
     "through": {
@@ -8089,20 +7179,14 @@
       "dev": true
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5",
-        "xtend": "4.0.1"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -8110,20 +7194,8 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
-    },
-    "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -8131,7 +7203,18 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "to-regex": {
@@ -8140,10 +7223,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -8152,27 +7235,15 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
-    "tough-cookie": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
-      "integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
-      "dev": true,
-      "requires": {
-        "psl": "1.1.27",
-        "punycode": "1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
-      }
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=",
+      "dev": true
     },
     "tr46": {
       "version": "1.0.1",
@@ -8180,7 +7251,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "trim-newlines": {
@@ -8195,16 +7266,10 @@
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
     "tslib": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
-      "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "tunnel-agent": {
@@ -8213,15 +7278,14 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -8229,7 +7293,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -8239,45 +7303,27 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
+      "integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
-          "optional": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
+        "commander": "~2.19.0",
+        "source-map": "~0.6.1"
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+      "dev": true
+    },
+    "umask": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",
@@ -8285,10 +7331,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -8297,7 +7343,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -8306,12 +7352,39 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
+      }
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dev": true,
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "universal-user-agent": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
+      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+      "dev": true,
+      "requires": {
+        "os-name": "^3.0.0"
       }
     },
     "universalify": {
@@ -8326,8 +7399,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -8336,9 +7409,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -8360,19 +7433,13 @@
         }
       }
     },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -8381,31 +7448,17 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
     },
     "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "dev": true,
-      "requires": {
-        "kind-of": "6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -8413,20 +7466,10 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
-      }
-    },
     "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -8435,8 +7478,17 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "dev": true,
+      "requires": {
+        "builtins": "^1.0.3"
       }
     },
     "verror": {
@@ -8445,45 +7497,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
-    },
-    "w3c-hr-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
-      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-      "dev": true,
-      "requires": {
-        "browser-process-hrtime": "0.1.2"
-      }
-    },
-    "walker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "1.0.11"
-      }
-    },
-    "watch": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-      "dev": true,
-      "requires": {
-        "exec-sh": "0.2.1",
-        "minimist": "1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
+        "extsprintf": "^1.2.0"
       }
     },
     "wcwidth": {
@@ -8492,7 +7508,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {
@@ -8501,47 +7517,13 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
     },
-    "whatwg-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.19"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
-        }
-      }
-    },
-    "whatwg-mimetype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
-      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
-      "dev": true,
-      "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
-      }
-    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -8556,15 +7538,47 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^1.0.2 || 2"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+    "windows-release": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "execa": "^0.10.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -8578,17 +7592,23 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -8597,9 +7617,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -8608,7 +7628,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -8620,23 +7640,23 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "write-json-file": {
@@ -8645,12 +7665,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "5.0.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "pify": "3.0.0",
-        "sort-keys": "2.0.0",
-        "write-file-atomic": "2.3.0"
+        "detect-indent": "^5.0.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "sort-keys": "^2.0.0",
+        "write-file-atomic": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -8667,25 +7687,9 @@
       "integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
       "dev": true,
       "requires": {
-        "sort-keys": "2.0.0",
-        "write-json-file": "2.3.0"
+        "sort-keys": "^2.0.0",
+        "write-json-file": "^2.2.0"
       }
-    },
-    "ws": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "xml-name-validator": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-      "dev": true
     },
     "xtend": {
       "version": "4.0.1",
@@ -8694,9 +7698,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
@@ -8706,142 +7710,92 @@
       "dev": true
     },
     "yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            }
+            "locate-path": "^3.0.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "parse-json": {
+        "p-limit": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "p-try": "^2.0.0"
           }
         },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "p-limit": "^2.0.0"
           }
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+        "p-try": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+          "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+          "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yup": {
+      "version": "0.26.10",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
+      "integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "7.0.0",
+        "fn-name": "~2.0.1",
+        "lodash": "^4.17.10",
+        "property-expr": "^1.5.0",
+        "synchronous-promise": "^2.0.5",
+        "toposort": "^2.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,17 +2,13 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "lerna run build",
     "check-branch": "enkidevs-assert-restricted-branch",
     "clean": "lerna run clean",
     "format": "prettier --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
     "lint": "eslint . --ignore-path .gitignore",
     "pre-commit-lint": "lint-staged",
-    "prebuild": "npm run clean && npm test && ",
     "publish-packages": "lerna publish",
-    "test:watch": "jest --watchAll",
-    "test": "jest --coverage --notify",
-    "test:regex": "npm test -- regexToMatchFile"
+    "test": "lerna run test"
   },
   "keywords": [
     "enki",
@@ -34,15 +30,12 @@
   "dependencies": {},
   "devDependencies": {
     "@enkidevs/assert-restricted-branch": "^1.0.2",
-    "@enkidevs/eslint-config-backend": "^0.1.1",
-    "eslint": "^5.8.0",
+    "@enkidevs/eslint-config-backend": "^0.3.1",
+    "eslint": "^5.15.3",
     "husky": "^1.1.3",
-    "jest": "^23.1.0",
-    "jest-in-case": "^1.0.2",
-    "jsonfile": "^4.0.0",
-    "lerna": "^2.11.0",
-    "lint-staged": "^7.3.0",
-    "prettier": "1.13.4"
+    "lerna": "^3.13.1",
+    "lint-staged": "^8.1.5",
+    "prettier": "^1.16.4"
   },
   "husky": {
     "hooks": {
@@ -59,16 +52,5 @@
         "git add"
       ]
     }
-  },
-  "jest": {
-    "testRegex": "packages/.*/__tests__/.*\\.test.js$",
-    "collectCoverageFrom": [
-      "**/*.{js,jsx}",
-      "!**/dist/**",
-      "!**/__tests__/**",
-      "!**/node_modules/**",
-      "!**/vendor/**",
-      "!**/*sandbox.js"
-    ]
   }
 }

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
@@ -3,7 +3,8 @@
   "children": [
     {
       "type": "yaml",
-      "value": "author: catalin\n\nlevels:\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\n\ntags:\n  - introduction\n  - workout\n\nstub: false\n\nlinks:\n  - '[EnkiCool](https://enki.com){website}'\n",
+      "value":
+        "author: catalin\n\nlevels:\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\n\ntags:\n  - introduction\n  - workout\n\nstub: false\n\nlinks:\n  - '[EnkiCool](https://enki.com){website}'\n",
       "position": {
         "start": {
           "line": 1,
@@ -46,21 +47,14 @@
       "data": {
         "parsedValue": {
           "author": "catalin",
-          "levels": [
-            "basic",
-            "medium",
-            "advanced"
-          ],
+          "levels": ["basic", "medium", "advanced"],
           "type": "normal",
           "category": "must-know",
           "standards": {
             "sql.use-dql.0": 10,
             "sql.use-ddl.1": 1000
           },
-          "tags": [
-            "introduction",
-            "workout"
-          ],
+          "tags": ["introduction", "workout"],
           "stub": false,
           "links": [
             {
@@ -155,6 +149,7 @@
             {
               "type": "linkReference",
               "identifier": "1",
+              "label": "1",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -227,6 +222,7 @@
             {
               "type": "linkReference",
               "identifier": "2",
+              "label": "2",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -297,11 +293,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -356,7 +352,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -438,9 +434,7 @@
               "column": 13,
               "offset": 391
             },
-            "indent": [
-              1
-            ]
+            "indent": [1]
           }
         },
         {
@@ -466,6 +460,7 @@
             {
               "type": "linkReference",
               "identifier": "3",
+              "label": "3",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -534,6 +529,7 @@
         },
         {
           "type": "code",
+          "meta": null,
           "lang": "javascript",
           "value": "console.log('sample code')",
           "position": {
@@ -547,10 +543,7 @@
               "column": 4,
               "offset": 453
             },
-            "indent": [
-              1,
-              1
-            ]
+            "indent": [1, 1]
           }
         }
       ]
@@ -633,11 +626,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -693,7 +686,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -749,7 +742,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -815,10 +808,7 @@
               "column": 15,
               "offset": 554
             },
-            "indent": [
-              1,
-              1
-            ]
+            "indent": [1, 1]
           },
           "answers": true
         }
@@ -938,11 +928,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -998,7 +988,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -1054,7 +1044,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -1110,7 +1100,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -1176,11 +1166,7 @@
               "column": 15,
               "offset": 674
             },
-            "indent": [
-              1,
-              1,
-              1
-            ]
+            "indent": [1, 1, 1]
           },
           "answers": true
         }
@@ -1252,11 +1238,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -1312,7 +1298,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -1386,7 +1372,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -1459,7 +1445,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -1525,11 +1511,7 @@
               "column": 7,
               "offset": 774
             },
-            "indent": [
-              1,
-              1,
-              1
-            ]
+            "indent": [1, 1, 1]
           },
           "answers": true
         }
@@ -1546,6 +1528,7 @@
             {
               "type": "linkReference",
               "identifier": "1: paragraph",
+              "label": "1: Paragraph",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -1594,9 +1577,7 @@
                   "column": 19,
                   "offset": 827
                 },
-                "indent": [
-                  1
-                ]
+                "indent": [1]
               }
             }
           ],
@@ -1611,9 +1592,7 @@
               "column": 19,
               "offset": 827
             },
-            "indent": [
-              1
-            ]
+            "indent": [1]
           }
         },
         {
@@ -1622,6 +1601,7 @@
             {
               "type": "linkReference",
               "identifier": "2: list",
+              "label": "2: List",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -1670,9 +1650,7 @@
                   "column": 12,
                   "offset": 850
                 },
-                "indent": [
-                  1
-                ]
+                "indent": [1]
               }
             }
           ],
@@ -1687,9 +1665,7 @@
               "column": 12,
               "offset": 850
             },
-            "indent": [
-              1
-            ]
+            "indent": [1]
           }
         },
         {
@@ -1698,6 +1674,7 @@
             {
               "type": "linkReference",
               "identifier": "3: code",
+              "label": "3: Code",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -1746,9 +1723,7 @@
                   "column": 12,
                   "offset": 873
                 },
-                "indent": [
-                  1
-                ]
+                "indent": [1]
               }
             }
           ],
@@ -1763,13 +1738,12 @@
               "column": 12,
               "offset": 873
             },
-            "indent": [
-              1
-            ]
+            "indent": [1]
           }
         },
         {
           "type": "code",
+          "meta": null,
           "lang": "javascript",
           "value": "var x = 10",
           "position": {
@@ -1783,10 +1757,7 @@
               "column": 4,
               "offset": 902
             },
-            "indent": [
-              1,
-              1
-            ]
+            "indent": [1, 1]
           }
         }
       ]

--- a/packages/curriculum-compiler-json/__tests__/fixtures/question/sample/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/question/sample/ast.json
@@ -46,11 +46,11 @@
       "type": "list",
       "ordered": false,
       "start": null,
-      "loose": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -67,7 +67,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -84,7 +84,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -101,7 +101,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {

--- a/packages/curriculum-compiler-json/compilers/footnotes.js
+++ b/packages/curriculum-compiler-json/compilers/footnotes.js
@@ -13,6 +13,7 @@ module.exports = function footnotes(node) {
 
 function parseRawFootnotes(text) {
   const splitTextArray = text.split(/(\[.*:.*\])/gi).filter(Boolean);
+  // eslint-disable-next-line max-params
   return splitTextArray.reduce((items, line, index, array) => {
     if (index % 2 === 1) {
       return items;

--- a/packages/curriculum-compiler-json/jest.config.js
+++ b/packages/curriculum-compiler-json/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testRegex: '.*/__tests__/.*\\.test.js$',
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/dist/**',
+    '!**/__tests__/**',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+    '!**/*sandbox.js',
+  ],
+};

--- a/packages/curriculum-compiler-json/package-lock.json
+++ b/packages/curriculum-compiler-json/package-lock.json
@@ -1,27 +1,4726 @@
 {
-	"requires": true,
+	"name": "@enkidevs/curriculum-compiler-json",
+	"version": "2.3.2",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+			"integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helpers": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
+			"integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+			"integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+			"dev": true
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+			"integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"dev": true,
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
+			}
+		},
+		"@enkidevs/curriculum-compiler-string": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-compiler-string/-/curriculum-compiler-string-2.2.1.tgz",
+			"integrity": "sha512-53pd12gEj9MMmv9rrcQm99Vrhcoj/I4EIN55zd7cx3hScA3K+5l4FvHZJ/OBhpFerVse2Pqz6aj3waSYHjKuyw==",
+			"requires": {
+				"@enkidevs/curriculum-helpers": "^2.2.1",
+				"@enkidevs/remark-stringify": "^5.1.1",
+				"js-yaml": "^3.11.0",
+				"unified": "^6.1.6"
+			}
+		},
+		"@enkidevs/curriculum-helpers": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-2.2.1.tgz",
+			"integrity": "sha512-wO3TWNR9gdNooG2IYn2YFgY8WspyOWP6KBF8tidkP4UwAka+/aDaKgnV2nZfdfwEs5SVY++StqQWto3Z/mtFbQ==",
+			"requires": {
+				"unist-util-assert": "^1.0.1",
+				"unist-util-map": "^1.0.3"
+			}
+		},
+		"@enkidevs/remark-stringify": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@enkidevs/remark-stringify/-/remark-stringify-5.1.1.tgz",
+			"integrity": "sha512-J+YP1z4gKTR+HZFfKWA2TzjQ+RZcstw79Hyy42cHwJc0LxmGd/GZoGEgkK18hCKJMTdVG6+Yr1tLvz3QWAUQHg==",
+			"requires": {
+				"ccount": "^1.0.0",
+				"is-alphanumeric": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"longest-streak": "^2.0.1",
+				"markdown-escapes": "^1.0.0",
+				"markdown-table": "^1.1.0",
+				"mdast-util-compact": "^1.0.0",
+				"parse-entities": "^1.0.2",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"stringify-entities": "^1.0.1",
+				"unherit": "^1.0.4",
+				"xtend": "^4.0.1"
+			}
+		},
+		"@jest/console": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
+			"integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
+			"dev": true,
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"@types/node": "*",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
+			"integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/reporters": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.5.0",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve-dependencies": "^24.5.0",
+				"jest-runner": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"jest-watcher": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"pirates": "^4.0.1",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"strip-ansi": "^5.0.0"
+			}
+		},
+		"@jest/environment": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
+			"integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
+			"integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
+			"integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-api": "^2.1.1",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"jest-haste-map": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"node-notifier": "^5.2.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
+			"integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/types": "^24.5.0",
+				"@types/istanbul-lib-coverage": "^1.1.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
+			"integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"jest-haste-map": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "2.4.1"
+			}
+		},
+		"@jest/types": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
+			"integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^1.1.0",
+				"@types/yargs": "^12.0.9"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
+			"integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
+			"integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+			"dev": true
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/yargs": {
+			"version": "12.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
+			"dev": true
+		},
+		"abab": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
+			}
+		},
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^2.0.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
+		},
+		"babel-jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
+			"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+			"dev": true,
+			"requires": {
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/babel__core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.3.0",
+				"chalk": "^2.4.2",
+				"slash": "^2.0.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
+			"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.0.0",
+				"test-exclude": "^5.0.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
+			"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+			"dev": true,
+			"requires": {
+				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
+			"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.3.0"
+			}
+		},
+		"bail": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
+		},
+		"browser-resolve": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"dev": true,
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
+		"callsites": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+			"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+			"dev": true
+		},
+		"capture-exit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+			"dev": true,
+			"requires": {
+				"rsvp": "^4.8.4"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"ccount": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+			"integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"character-entities": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
+		},
+		"character-entities-html4": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
+			"integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw=="
+		},
+		"character-entities-legacy": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
+		},
+		"character-reference-invalid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
+		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"dev": true,
+			"optional": true
+		},
+		"compare-versions": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"cssom": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+			"integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+			"dev": true,
+			"requires": {
+				"cssom": "0.3.x"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"dev": true
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"dev": true,
+			"requires": {
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				}
+			}
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"exec-sh": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+			"dev": true
+		},
+		"execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"expect": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
+			"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-styles": "^3.2.0",
+				"jest-get-type": "^24.3.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0"
+			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
+			"requires": {
+				"bser": "^2.0.0"
+			}
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
+			}
+		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^3.0.0"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "^1.0.1"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"import-local": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^3.0.0",
+				"resolve-cwd": "^2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"invert-kv": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"dev": true
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-alphabetical": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
+		},
+		"is-alphanumeric": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
+		},
+		"is-alphanumerical": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+			"requires": {
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
+		"is-decimal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-generator-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+			"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+			"dev": true
+		},
+		"is-hexadecimal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"is-whitespace-character": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
+			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"istanbul-api": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
+			"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+			"dev": true,
+			"requires": {
+				"async": "^2.6.1",
+				"compare-versions": "^3.2.1",
+				"fileset": "^2.0.3",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.1.0",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.1",
+				"js-yaml": "^3.12.0",
+				"make-dir": "^1.3.0",
+				"minimatch": "^3.0.4",
+				"once": "^1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+			"dev": true,
+			"requires": {
+				"append-transform": "^1.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.3",
+				"semver": "^5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+			"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"supports-color": "^6.0.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+			"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"rimraf": "^2.6.2",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+			"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+			"dev": true,
+			"requires": {
+				"handlebars": "^4.1.0"
+			}
+		},
+		"jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
+			"integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
+			"dev": true,
+			"requires": {
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.5.0"
+			},
+			"dependencies": {
+				"jest-cli": {
+					"version": "24.5.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
+					"integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^24.5.0",
+						"@jest/test-result": "^24.5.0",
+						"@jest/types": "^24.5.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.5.0",
+						"jest-util": "^24.5.0",
+						"jest-validate": "^24.5.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^12.0.2"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
+			"integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"execa": "^1.0.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-config": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
+			"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-jest": "^24.5.0",
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^24.5.0",
+				"jest-environment-node": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.5.0",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-diff": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
+			"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"dev": true,
+			"requires": {
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
+			"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
+			"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jsdom": "^11.5.1"
+			}
+		},
+		"jest-environment-node": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
+			"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+			"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+			"dev": true
+		},
+		"jest-haste-map": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
+			"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"invariant": "^2.2.4",
+				"jest-serializer": "^24.4.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"micromatch": "^3.1.10",
+				"sane": "^4.0.3"
+			}
+		},
+		"jest-in-case": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/jest-in-case/-/jest-in-case-1.0.2.tgz",
+			"integrity": "sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=",
+			"dev": true
+		},
+		"jest-jasmine2": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
+			"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^24.5.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
+			"integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
+			"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"jest-diff": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
+			"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
+			"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"dev": true
+		},
+		"jest-regex-util": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
+			"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"jest-pnp-resolver": "^1.2.1",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
+			"integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.5.0"
+			}
+		},
+		"jest-runner": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
+			"integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.4.2",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-docblock": "^24.3.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-leak-detector": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
+			"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/yargs": "^12.0.2",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"strip-bom": "^3.0.0",
+				"yargs": "^12.0.2"
+			}
+		},
+		"jest-serializer": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"dev": true
+		},
+		"jest-snapshot": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
+			"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"expect": "^24.5.0",
+				"jest-diff": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^24.5.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"jest-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
+			"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"callsites": "^3.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"jest-validate": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+			"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"camelcase": "^5.0.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
+			"integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"@types/yargs": "^12.0.9",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"jest-util": "^24.5.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"jest-worker": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
+			"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"jsdom": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.9.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
+				"parse5": "4.0.0",
+				"pn": "^1.1.0",
+				"request": "^2.87.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.4",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"json5": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
+		"jsonfile": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+			"integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^0.1.2"
+			}
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
+			"integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==",
+			"dev": true
+		},
+		"lcid": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"dev": true,
+			"requires": {
+				"invert-kv": "^2.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
+		"longest-streak": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
+			"integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA=="
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
+			"requires": {
+				"tmpl": "1.0.x"
+			}
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"markdown-escapes": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
+			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
+		},
+		"markdown-table": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
+			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw=="
+		},
+		"mdast-util-compact": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
+			"integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"mem": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+			"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+			"dev": true,
+			"requires": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			}
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
+		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			}
+		},
+		"mime-db": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"dev": true,
+			"requires": {
+				"mime-db": "~1.38.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+			"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
+		},
+		"node-notifier": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"dev": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "^2.0.0"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"nwsapi": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+			"integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"unist-builder": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
-			"integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+			"integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"dev": true,
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			}
+		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-is-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"dev": true,
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
+		},
+		"p-try": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+			"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+			"dev": true
+		},
+		"parse-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
+			"integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
+			"requires": {
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
+		},
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"dev": true,
+			"requires": {
+				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"pretty-format": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+			"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
+			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"prompts": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+			"integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.2",
+				"sisteransi": "^1.0.0"
+			}
+		},
+		"psl": {
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
+		},
+		"react-is": {
+			"version": "16.8.5",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+			"integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
+			"dev": true
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"realpath-native": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+			"dev": true,
+			"requires": {
+				"util.promisify": "^1.0.0"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+		},
+		"request": {
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"rsvp": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"sane": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+			"dev": true,
+			"requires": {
+				"@cnakazawa/watch": "^1.0.3",
+				"anymatch": "^2.0.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
+				"fb-watchman": "^2.0.0",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5"
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sisteransi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"dev": true
+		},
+		"slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+			"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+			"dev": true
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
+		},
+		"state-toggle": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
+			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"stringify-entities": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+			"requires": {
+				"character-entities-html4": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^4.1.0"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
+		},
+		"test-exclude": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^1.0.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"trough": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw=="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"uglify-js": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
+			"integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.19.0",
+				"source-map": "~0.6.1"
+			}
+		},
+		"unherit": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
+			}
+		},
+		"unified": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"requires": {
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^2.0.0",
+				"x-is-string": "^0.1.0"
+			}
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
+		},
+		"unist-builder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.3.tgz",
+			"integrity": "sha512-/KB8GEaoeHRyIqClL+Kam+Y5NWJ6yEiPsAfv1M+O1p+aKGgjR89WwoEHKTyOj17L6kAlqtKpAgv2nWvdbQDEig==",
+			"requires": {
+				"object-assign": "^4.1.0"
 			}
 		},
 		"unist-util-assert": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-assert/-/unist-util-assert-1.0.2.tgz",
-			"integrity": "sha512-HbAeG1smDbSirJySgqZ7nbKdygmuL0s/1MMPXaHrChWMKueYuRHfk5R8EmlDV0vPfP8uLwazrvpu0ZkVYZD/xg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-assert/-/unist-util-assert-1.0.3.tgz",
+			"integrity": "sha512-0b1jHm8h5Hbz/prQAcg36uUUQeNaih09iwDBMxNrD2gejL7fs6W12jUJgwuHi+OC4fRztpPbNIbMnfspemmdGQ==",
 			"requires": {
-				"x-is-array": "0.1.0",
-				"x-is-object": "0.1.0"
+				"x-is-array": "^0.1.0",
+				"x-is-object": "^0.1.0"
+			}
+		},
+		"unist-util-is": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+		},
+		"unist-util-map": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-1.0.4.tgz",
+			"integrity": "sha512-Qv68pQz05hQbjPI+TubZQI5XII5DScRVWaKNc6+qfmHaFGxaGUbkV8i++mM2nk7XgwXE+vei99d/Q2d1tMA3EQ==",
+			"requires": {
+				"object-assign": "^4.0.1"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+		},
+		"unist-util-visit": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+			"integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+			"requires": {
+				"unist-util-visit-parents": "^2.0.0"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+			"integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+			"requires": {
+				"unist-util-is": "^2.1.2"
+			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"vfile": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"requires": {
+				"is-buffer": "^1.1.4",
+				"replace-ext": "1.0.0",
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			}
+		},
+		"vfile-message": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"requires": {
+				"unist-util-stringify-position": "^1.1.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
+			"requires": {
+				"makeerror": "1.0.x"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
+		},
+		"whatwg-encoding": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.24"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write-file-atomic": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"ws": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"x-is-array": {
@@ -33,6 +4732,58 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/x-is-object/-/x-is-object-0.1.0.tgz",
 			"integrity": "sha1-j5SW0Wht9IcVYJbnbKmUTvwVv+w="
+		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^4.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
+			}
+		},
+		"yargs-parser": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
 		}
 	}
 }

--- a/packages/curriculum-compiler-json/package.json
+++ b/packages/curriculum-compiler-json/package.json
@@ -4,6 +4,11 @@
   "description": "Compile Enki Curriculum AST to JSON object",
   "author": "loopiezlol <loopiezlol@gmail.com>",
   "main": "index.js",
+  "scripts": {
+    "test:watch": "jest --watchAll",
+    "test": "jest --coverage --notify",
+    "test:regex": "npm test -- regexToMatchFile"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/enkidevs/curriculum-processors.git"
@@ -16,13 +21,22 @@
   "engines": {
     "node": ">=8.10.0"
   },
+  "files": [
+    "index.js",
+    "compilers"
+  ],
   "dependencies": {
     "@enkidevs/curriculum-compiler-string": "^2.2.1",
     "@enkidevs/curriculum-helpers": "^2.2.1",
-    "unist-builder": "^1.0.2",
-    "unist-util-assert": "^1.0.2"
+    "unist-builder": "^1.0.3",
+    "unist-util-assert": "^1.0.3"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "jest": "^24.5.0",
+    "jest-in-case": "^1.0.2",
+    "jsonfile": "^5.0.0"
   }
 }

--- a/packages/curriculum-compiler-react/package-lock.json
+++ b/packages/curriculum-compiler-react/package-lock.json
@@ -1,11 +1,42 @@
 {
-	"requires": true,
+	"name": "@enkidevs/curriculum-compiler-react",
+	"version": "2.1.5",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
-		"asap": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+		},
+		"@types/unist": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+		},
+		"@types/vfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*",
+				"@types/vfile-message": "*"
+			}
+		},
+		"@types/vfile-message": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*"
+			}
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"bail": {
 			"version": "1.0.3",
@@ -25,166 +56,100 @@
 				"trim": "0.0.1"
 			}
 		},
-		"core-js": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-		},
-		"define-properties": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+		"css": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"inherits": "^2.0.3",
+				"source-map": "^0.6.1",
+				"source-map-resolve": "^0.5.2",
+				"urix": "^0.1.0"
 			}
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"detab": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
 			"integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
 			"requires": {
-				"repeat-string": "1.6.1"
-			}
-		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "0.4.23"
+				"repeat-string": "^1.5.4"
 			}
 		},
 		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-		},
-		"fbjs": {
-			"version": "0.8.16",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.18"
-			}
-		},
-		"flatmap": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
-			"integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
-		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"hast-to-hyperscript": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-4.0.0.tgz",
-			"integrity": "sha512-4kOn4ihjDJTQg7B53ZcZ6NyExtTeG3hLNZv6rSKhq4haQvD52zCllE+49iLiC1VWuc4DbHmt96FHPGlHbslZqQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-6.0.0.tgz",
+			"integrity": "sha512-QnJbXddVGNJ5v3KegK1MY6luTkNDBcJnCQZcekt7AkES2z4tYy85pbFUXx7Mb0iXZBKfwoVdgfxU12GbmlwbbQ==",
 			"requires": {
-				"comma-separated-tokens": "1.0.5",
-				"is-nan": "1.2.1",
-				"kebab-case": "1.0.0",
-				"property-information": "3.2.0",
-				"space-separated-tokens": "1.1.2",
-				"trim": "0.0.1",
-				"unist-util-is": "2.1.2"
+				"comma-separated-tokens": "^1.0.0",
+				"property-information": "^5.0.0",
+				"space-separated-tokens": "^1.0.0",
+				"style-to-object": "^0.2.1",
+				"unist-util-is": "^2.0.0",
+				"web-namespaces": "^1.1.2"
 			}
 		},
-		"iconv-lite": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-			"requires": {
-				"safer-buffer": "2.1.2"
-			}
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-		},
-		"is-nan": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
-			"integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
-			"requires": {
-				"define-properties": "1.1.2"
-			}
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+			"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"isomorphic-fetch": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.4"
-			}
-		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-		},
-		"kebab-case": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
-			"integrity": "sha1-P55JkK3K0MaGwOcB92RYaPdfkes="
-		},
-		"lodash.identity": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
-			"integrity": "sha1-rXvGpOZH15yXLhuA/u968VYmeHY="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"mdast-util-definitions": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
-			"integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.3.tgz",
+			"integrity": "sha512-P6wpRO8YVQ1iv30maMc93NLh7COvufglBE8/ldcOyYmk5EbfF0YeqlLgtqP/FOBU501Kqar1x5wYWwB3Nga74g==",
 			"requires": {
-				"unist-util-visit": "1.3.1"
+				"unist-util-visit": "^1.0.0"
 			}
 		},
 		"mdast-util-to-hast": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.1.tgz",
-			"integrity": "sha512-+eimV/12kdg0/T0EEfcK7IsDbSu2auVm92z5jdSEQ3DHF2HiU4OHmX9ir5wpQajr73nwabdxrUoxREvW2zVFFw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
+			"integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
 			"requires": {
-				"collapse-white-space": "1.0.4",
-				"detab": "2.0.1",
-				"mdast-util-definitions": "1.2.2",
-				"mdurl": "1.0.1",
+				"collapse-white-space": "^1.0.0",
+				"detab": "^2.0.0",
+				"mdast-util-definitions": "^1.2.0",
+				"mdurl": "^1.0.1",
 				"trim": "0.0.1",
-				"trim-lines": "1.1.1",
-				"unist-builder": "1.0.2",
-				"unist-util-generated": "1.1.2",
-				"unist-util-position": "3.0.1",
-				"unist-util-visit": "1.3.1",
-				"xtend": "4.0.1"
+				"trim-lines": "^1.0.0",
+				"unist-builder": "^1.0.1",
+				"unist-util-generated": "^1.1.0",
+				"unist-util-position": "^3.0.0",
+				"unist-util-visit": "^1.1.0",
+				"xtend": "^4.0.1"
 			}
 		},
 		"mdurl": {
@@ -192,65 +157,51 @@
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
 			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
-			}
-		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"object-keys": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
-		},
-		"promise": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-			"requires": {
-				"asap": "2.0.6"
-			}
-		},
 		"prop-types": {
-			"version": "15.6.1",
-			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-			"integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
 			}
 		},
 		"property-information": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/property-information/-/property-information-3.2.0.tgz",
-			"integrity": "sha1-/RSDyPusYYCPX+NZ52k6H0ilgzE="
-		},
-		"react": {
-			"version": "16.4.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.4.0.tgz",
-			"integrity": "sha512-K0UrkLXSAekf5nJu89obKUM7o2vc6MMN9LYoKnCa+c+8MJRAT120xzPLENcWSRc7GYKIg0LlgJRDorrufdglQQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.0.1.tgz",
+			"integrity": "sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.1"
+				"xtend": "^4.0.1"
 			}
 		},
-		"remark-rehype": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-3.0.0.tgz",
-			"integrity": "sha512-WUinfb6vi34f4VYs2XS4HvuYNd0tCu68HOlG4aMp1dfFyVuVfL3aiL9WPw+Q6W99xTTHyxwr7BGO94jF0psoEA==",
+		"react": {
+			"version": "16.8.5",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.8.5.tgz",
+			"integrity": "sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==",
 			"requires": {
-				"mdast-util-to-hast": "3.0.1"
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.13.5"
+			}
+		},
+		"react-is": {
+			"version": "16.8.5",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+			"integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ=="
+		},
+		"remark-rehype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-4.0.0.tgz",
+			"integrity": "sha512-SwrU3EhLbFSZCp8xFb56B7+LkN1aIdXmu4hEAwyX/27r65oZsNGSV4Rl7kJZl0oF7Gz+Z5iQXZl6tQxJNc4gYQ==",
+			"requires": {
+				"mdast-util-to-hast": "^4.0.0"
 			}
 		},
 		"repeat-string": {
@@ -263,15 +214,41 @@
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
-		"setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		"scheduler": {
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.5.tgz",
+			"integrity": "sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==",
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"space-separated-tokens": {
 			"version": "1.1.2",
@@ -279,6 +256,14 @@
 			"integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
 			"requires": {
 				"trim": "0.0.1"
+			}
+		},
+		"style-to-object": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.2.tgz",
+			"integrity": "sha512-GcbtvfsqyKmIPpHeOHZ5Rmwsx2MDJct4W9apmTGcbPTbpA2FcgTFl2Z43Hm4Qb61MWGPNK8Chki7ITiY7lLOow==",
+			"requires": {
+				"css": "2.2.4"
 			}
 		},
 		"trim": {
@@ -292,56 +277,37 @@
 			"integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg=="
 		},
 		"trough": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
-			"integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ=="
-		},
-		"ua-parser-js": {
-			"version": "0.7.18",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-			"integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw=="
 		},
 		"unified": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
 			"requires": {
-				"bail": "1.0.3",
-				"extend": "3.0.1",
-				"is-plain-obj": "1.1.0",
-				"trough": "1.0.2",
-				"vfile": "2.3.0",
-				"x-is-string": "0.1.0"
+				"@types/unist": "^2.0.0",
+				"@types/vfile": "^3.0.0",
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^3.0.0",
+				"x-is-string": "^0.1.0"
 			}
 		},
 		"unist-builder": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
-			"integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.3.tgz",
+			"integrity": "sha512-/KB8GEaoeHRyIqClL+Kam+Y5NWJ6yEiPsAfv1M+O1p+aKGgjR89WwoEHKTyOj17L6kAlqtKpAgv2nWvdbQDEig==",
 			"requires": {
-				"object-assign": "4.1.1"
-			}
-		},
-		"unist-util-filter": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-0.2.1.tgz",
-			"integrity": "sha1-4veHaCiQOmqTCONiBR+GsU81tUU=",
-			"requires": {
-				"flatmap": "0.0.3",
-				"unist-util-is": "1.0.0"
-			},
-			"dependencies": {
-				"unist-util-is": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-1.0.0.tgz",
-					"integrity": "sha1-THs8XA9qqWNkAFb+Sve1/P27jvA="
-				}
+				"object-assign": "^4.1.0"
 			}
 		},
 		"unist-util-generated": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.2.tgz",
-			"integrity": "sha512-1HcwiEO62dr0XWGT+abVK4f0aAm8Ik8N08c5nAYVmuSxfvpA9rCcNyX/le8xXj1pJK5nBrGlZefeWB6bN8Pstw=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.3.tgz",
+			"integrity": "sha512-qlPeDqnQnd84KIqwphzOR+l02cxjDzvEYEBl84EjmKRrX4eUmjyAo8xJv1SCDhJqNjyHRnBMZWNKAiBtXE6hBg=="
 		},
 		"unist-util-is": {
 			"version": "2.1.2",
@@ -353,13 +319,13 @@
 			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-1.0.4.tgz",
 			"integrity": "sha512-Qv68pQz05hQbjPI+TubZQI5XII5DScRVWaKNc6+qfmHaFGxaGUbkV8i++mM2nk7XgwXE+vei99d/Q2d1tMA3EQ==",
 			"requires": {
-				"object-assign": "4.1.1"
+				"object-assign": "^4.0.1"
 			}
 		},
 		"unist-util-position": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.1.tgz",
-			"integrity": "sha512-05QfJDPI7PE1BIUtAxeSV+cDx21xP7+tUZgSval5CA7tr0pHBwybF7OnEa1dOFqg6BfYH/qiMUnWwWj+Frhlww=="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.2.tgz",
+			"integrity": "sha512-npmFu92l/+b1Ao6uGP4I1WFz9hsKv7qleZ4aliw6x0RVu6A9A3tAf57NMpFfzQ02jxRtJZuRn+C8xWT7GWnH0g=="
 		},
 		"unist-util-stringify-position": {
 			"version": "1.1.2",
@@ -367,36 +333,49 @@
 			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
 		},
 		"unist-util-visit": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
-			"integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+			"integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
 			"requires": {
-				"unist-util-is": "2.1.2"
+				"unist-util-visit-parents": "^2.0.0"
 			}
 		},
-		"vfile": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+		"unist-util-visit-parents": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+			"integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
 			"requires": {
-				"is-buffer": "1.1.6",
+				"unist-util-is": "^2.1.2"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+		},
+		"vfile": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+			"requires": {
+				"is-buffer": "^2.0.0",
 				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "1.1.2",
-				"vfile-message": "1.0.1"
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
 			}
 		},
 		"vfile-message": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
-			"integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
 			"requires": {
-				"unist-util-stringify-position": "1.1.2"
+				"unist-util-stringify-position": "^1.1.1"
 			}
 		},
-		"whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+		"web-namespaces": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.2.tgz",
+			"integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg=="
 		},
 		"x-is-string": {
 			"version": "0.1.0",

--- a/packages/curriculum-compiler-react/package.json
+++ b/packages/curriculum-compiler-react/package.json
@@ -19,15 +19,16 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
-    "hast-to-hyperscript": "^4.0.0",
-    "lodash.identity": "^3.0.0",
-    "mdast-util-to-hast": "^3.0.0",
-    "react": "^16.3.1",
-    "remark-rehype": "^3.0.0",
-    "unified": "^6.1.6",
-    "unist-builder": "^1.0.2",
-    "unist-util-filter": "^0.2.1",
+    "hast-to-hyperscript": "^6.0.0",
+    "mdast-util-to-hast": "^4.0.0",
+    "react": "^16.8.5",
+    "remark-rehype": "^4.0.0",
+    "unified": "^7.1.0",
+    "unist-builder": "^1.0.3",
     "unist-util-map": "^1.0.3"
   }
 }

--- a/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/ast.json
@@ -3,22 +3,19 @@
   "children": [
     {
       "type": "yaml",
-      "value": "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n    - >-\n        [Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}\n\nparent: removing-keys-from-a-binary-search-tree",
+      "value":
+        "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n    - >-\n        [Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}\n\nparent: removing-keys-from-a-binary-search-tree",
       "data": {
         "parsedValue": {
           "author": "jfarmer",
-          "levels": [
-            "beginner",
-            "basic",
-            "medium",
-            "advanced"
-          ],
+          "levels": ["beginner", "basic", "medium", "advanced"],
           "type": "normal",
           "category": "must-know",
           "links": [
             {
               "name": "Why is it safer to keep the tree balanced?",
-              "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
+              "url":
+                "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
               "nature": "website"
             }
           ],
@@ -58,7 +55,8 @@
             },
             {
               "type": "text",
-              "value": " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application."
+              "value":
+                " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application."
             }
           ]
         },
@@ -67,7 +65,8 @@
           "children": [
             {
               "type": "text",
-              "value": "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree."
+              "value":
+                "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree."
             }
           ]
         },
@@ -76,7 +75,8 @@
           "children": [
             {
               "type": "text",
-              "value": "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:"
+              "value":
+                "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:"
             }
           ]
         },
@@ -86,7 +86,8 @@
             {
               "type": "image",
               "title": null,
-              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "url":
+                "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
               "alt": "unbalanced",
               "svg": true
             }
@@ -115,7 +116,8 @@
             {
               "type": "image",
               "title": null,
-              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "url":
+                "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
               "alt": "balanced",
               "svg": true
             }
@@ -126,7 +128,8 @@
           "children": [
             {
               "type": "text",
-              "value": "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching "
+              "value":
+                "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching "
             },
             {
               "type": "emphasis",
@@ -148,11 +151,13 @@
           "children": [
             {
               "type": "text",
-              "value": "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees"
+              "value":
+                "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees"
             },
             {
               "type": "linkReference",
               "identifier": "1",
+              "label": "1",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -168,6 +173,7 @@
             {
               "type": "linkReference",
               "identifier": "2",
+              "label": "2",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -223,11 +229,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -243,7 +249,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -259,7 +265,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -275,7 +281,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -303,6 +309,7 @@
             {
               "type": "linkReference",
               "identifier": "1: avl tree",
+              "label": "1: AVL tree",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -313,7 +320,8 @@
             },
             {
               "type": "text",
-              "value": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one."
+              "value":
+                "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one."
             }
           ]
         },
@@ -333,7 +341,8 @@
             },
             {
               "type": "text",
-              "value": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black."
+              "value":
+                "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black."
             }
           ]
         }

--- a/packages/curriculum-compiler-string/__tests__/fixtures/question/code/ast.json
+++ b/packages/curriculum-compiler-string/__tests__/fixtures/question/code/ast.json
@@ -29,6 +29,7 @@
     {
       "type": "questionCode",
       "lang": "bash",
+      "meta": null,
       "value": "$ ??? ??? ??? eth0",
       "children": [
         {
@@ -74,11 +75,11 @@
       "type": "list",
       "ordered": false,
       "start": null,
-      "loose": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -95,7 +96,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -112,7 +113,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -129,7 +130,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -146,7 +147,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {

--- a/packages/curriculum-compiler-string/__tests__/fixtures/question/quiz/ast.json
+++ b/packages/curriculum-compiler-string/__tests__/fixtures/question/quiz/ast.json
@@ -33,11 +33,11 @@
       "type": "list",
       "ordered": false,
       "start": null,
-      "loose": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -53,7 +53,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -69,7 +69,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -85,7 +85,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {

--- a/packages/curriculum-compiler-string/index.js
+++ b/packages/curriculum-compiler-string/index.js
@@ -20,9 +20,8 @@ function getCompiler(type) {
   function compile(ast) {
     return new Promise((resolve, reject) => {
       const processor = unified().use(getPlugins(type));
-      processor.run(
-        ast,
-        (err, res) => (err ? reject(err) : resolve(processor.stringify(res)))
+      processor.run(ast, (err, res) =>
+        err ? reject(err) : resolve(processor.stringify(res))
       );
     });
   }

--- a/packages/curriculum-compiler-string/jest.config.js
+++ b/packages/curriculum-compiler-string/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testRegex: '.*/__tests__/.*\\.test.js$',
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/dist/**',
+    '!**/__tests__/**',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+    '!**/*sandbox.js',
+  ],
+};

--- a/packages/curriculum-compiler-string/package-lock.json
+++ b/packages/curriculum-compiler-string/package-lock.json
@@ -1,26 +1,572 @@
 {
-	"requires": true,
+	"name": "@enkidevs/curriculum-compiler-string",
+	"version": "2.2.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+			"integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helpers": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
+			"integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+			"integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+			"dev": true
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+			"integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"dev": true,
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
+			}
+		},
 		"@enkidevs/remark-stringify": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/@enkidevs/remark-stringify/-/remark-stringify-5.1.1.tgz",
 			"integrity": "sha512-J+YP1z4gKTR+HZFfKWA2TzjQ+RZcstw79Hyy42cHwJc0LxmGd/GZoGEgkK18hCKJMTdVG6+Yr1tLvz3QWAUQHg==",
 			"requires": {
-				"ccount": "1.0.3",
-				"is-alphanumeric": "1.0.0",
-				"is-decimal": "1.0.2",
-				"is-whitespace-character": "1.0.2",
-				"longest-streak": "2.0.2",
-				"markdown-escapes": "1.0.2",
-				"markdown-table": "1.1.2",
-				"mdast-util-compact": "1.0.1",
-				"parse-entities": "1.1.2",
-				"repeat-string": "1.6.1",
-				"state-toggle": "1.0.1",
-				"stringify-entities": "1.3.2",
-				"unherit": "1.1.1",
-				"xtend": "4.0.1"
+				"ccount": "^1.0.0",
+				"is-alphanumeric": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"longest-streak": "^2.0.1",
+				"markdown-escapes": "^1.0.0",
+				"markdown-table": "^1.1.0",
+				"mdast-util-compact": "^1.0.0",
+				"parse-entities": "^1.0.2",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"stringify-entities": "^1.0.1",
+				"unherit": "^1.0.4",
+				"xtend": "^4.0.1"
+			}
+		},
+		"@jest/console": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
+			"integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
+			"dev": true,
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"@types/node": "*",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
+			"integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/reporters": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.5.0",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve-dependencies": "^24.5.0",
+				"jest-runner": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"jest-watcher": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"pirates": "^4.0.1",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"strip-ansi": "^5.0.0"
+			}
+		},
+		"@jest/environment": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
+			"integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
+			"integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
+			"integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-api": "^2.1.1",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"jest-haste-map": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"node-notifier": "^5.2.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
+			"integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/types": "^24.5.0",
+				"@types/istanbul-lib-coverage": "^1.1.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
+			"integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"jest-haste-map": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "2.4.1"
+			}
+		},
+		"@jest/types": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
+			"integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^1.1.0",
+				"@types/yargs": "^12.0.9"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
+			"integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
+			"integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/unist": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+		},
+		"@types/vfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*",
+				"@types/vfile-message": "*"
+			}
+		},
+		"@types/vfile-message": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*"
+			}
+		},
+		"@types/yargs": {
+			"version": "12.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
+			"dev": true
+		},
+		"abab": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
+			}
+		},
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^2.0.0"
 			}
 		},
 		"argparse": {
@@ -28,23 +574,372 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-iterate": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.2.tgz",
 			"integrity": "sha512-1hWSHTIlG/8wtYD+PPX5AOBtKWngpDFjrsrHgZpe+JdgNGz0udYu6ZIkAa/xuenIUEqFv7DvE2Yr60jxweJSrQ=="
 		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
+		},
+		"babel-jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
+			"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+			"dev": true,
+			"requires": {
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/babel__core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.3.0",
+				"chalk": "^2.4.2",
+				"slash": "^2.0.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
+			"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.0.0",
+				"test-exclude": "^5.0.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
+			"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+			"dev": true,
+			"requires": {
+				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
+			"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.3.0"
+			}
+		},
 		"bail": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
 			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
 		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
+		},
+		"browser-resolve": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"dev": true,
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
+		"callsites": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+			"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+			"dev": true
+		},
+		"capture-exit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+			"dev": true,
+			"requires": {
+				"rsvp": "^4.8.4"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
 		"ccount": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
 			"integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
 		},
 		"character-entities": {
 			"version": "1.2.2",
@@ -66,20 +961,955 @@
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
 			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
 		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"dev": true,
+			"optional": true
+		},
+		"compare-versions": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"cssom": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+			"integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+			"dev": true,
+			"requires": {
+				"cssom": "0.3.x"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"dev": true
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"dev": true,
+			"requires": {
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				}
+			}
+		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"exec-sh": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+			"dev": true
+		},
+		"execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"expect": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
+			"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-styles": "^3.2.0",
+				"jest-get-type": "^24.3.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0"
+			}
 		},
 		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
+			"requires": {
+				"bser": "^2.0.0"
+			}
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
+			}
+		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^3.0.0"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "^1.0.1"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"import-local": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^3.0.0",
+				"resolve-cwd": "^2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
 		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"invert-kv": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"dev": true
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"is-alphabetical": {
 			"version": "1.0.2",
@@ -96,48 +1926,996 @@
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
 			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
 			"requires": {
-				"is-alphabetical": "1.0.2",
-				"is-decimal": "1.0.2"
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
 			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-decimal": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
 			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
 		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-generator-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+			"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+			"dev": true
+		},
 		"is-hexadecimal": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
 			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
 		"is-whitespace-character": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
 			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
 		},
-		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"istanbul-api": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
+			"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"async": "^2.6.1",
+				"compare-versions": "^3.2.1",
+				"fileset": "^2.0.3",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.1.0",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.1",
+				"js-yaml": "^3.12.0",
+				"make-dir": "^1.3.0",
+				"minimatch": "^3.0.4",
+				"once": "^1.4.0"
 			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+			"dev": true,
+			"requires": {
+				"append-transform": "^1.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.3",
+				"semver": "^5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+			"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"supports-color": "^6.0.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+			"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"rimraf": "^2.6.2",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+			"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+			"dev": true,
+			"requires": {
+				"handlebars": "^4.1.0"
+			}
+		},
+		"jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
+			"integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
+			"dev": true,
+			"requires": {
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.5.0"
+			},
+			"dependencies": {
+				"jest-cli": {
+					"version": "24.5.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
+					"integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^24.5.0",
+						"@jest/test-result": "^24.5.0",
+						"@jest/types": "^24.5.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.5.0",
+						"jest-util": "^24.5.0",
+						"jest-validate": "^24.5.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^12.0.2"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
+			"integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"execa": "^1.0.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-config": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
+			"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-jest": "^24.5.0",
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^24.5.0",
+				"jest-environment-node": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.5.0",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-diff": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
+			"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"dev": true,
+			"requires": {
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
+			"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
+			"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jsdom": "^11.5.1"
+			}
+		},
+		"jest-environment-node": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
+			"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+			"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+			"dev": true
+		},
+		"jest-haste-map": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
+			"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"invariant": "^2.2.4",
+				"jest-serializer": "^24.4.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"micromatch": "^3.1.10",
+				"sane": "^4.0.3"
+			}
+		},
+		"jest-in-case": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/jest-in-case/-/jest-in-case-1.0.2.tgz",
+			"integrity": "sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=",
+			"dev": true
+		},
+		"jest-jasmine2": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
+			"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^24.5.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
+			"integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
+			"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"jest-diff": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
+			"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
+			"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"dev": true
+		},
+		"jest-regex-util": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
+			"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"jest-pnp-resolver": "^1.2.1",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
+			"integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.5.0"
+			}
+		},
+		"jest-runner": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
+			"integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.4.2",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-docblock": "^24.3.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-leak-detector": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
+			"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/yargs": "^12.0.2",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"strip-bom": "^3.0.0",
+				"yargs": "^12.0.2"
+			}
+		},
+		"jest-serializer": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"dev": true
+		},
+		"jest-snapshot": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
+			"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"expect": "^24.5.0",
+				"jest-diff": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^24.5.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"jest-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
+			"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"callsites": "^3.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"jest-validate": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+			"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"camelcase": "^5.0.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
+			"integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"@types/yargs": "^12.0.9",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"jest-util": "^24.5.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"jest-worker": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
+			"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"jsdom": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.9.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
+				"parse5": "4.0.0",
+				"pn": "^1.1.0",
+				"request": "^2.87.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.4",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"json5": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
+		"jsonfile": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+			"integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^0.1.2"
+			}
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
+			"integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==",
+			"dev": true
+		},
+		"lcid": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"dev": true,
+			"requires": {
+				"invert-kv": "^2.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
 		},
 		"longest-streak": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
 			"integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA=="
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
+			"requires": {
+				"tmpl": "1.0.x"
+			}
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
 		},
 		"markdown-escapes": {
 			"version": "1.0.2",
@@ -154,22 +2932,667 @@
 			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
 			"integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
 			"requires": {
-				"unist-util-modify-children": "1.1.2",
-				"unist-util-visit": "1.3.1"
+				"unist-util-modify-children": "^1.0.0",
+				"unist-util-visit": "^1.1.0"
 			}
+		},
+		"mem": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+			"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+			"dev": true,
+			"requires": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			}
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
+		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			}
+		},
+		"mime-db": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"dev": true,
+			"requires": {
+				"mime-db": "~1.38.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+			"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
+		},
+		"node-notifier": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"dev": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "^2.0.0"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"nwsapi": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+			"integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+			"integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"dev": true,
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			}
+		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-is-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"dev": true,
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
+		},
+		"p-try": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+			"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+			"dev": true
 		},
 		"parse-entities": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
 			"integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
 			"requires": {
-				"character-entities": "1.2.2",
-				"character-entities-legacy": "1.1.2",
-				"character-reference-invalid": "1.1.2",
-				"is-alphanumerical": "1.0.2",
-				"is-decimal": "1.0.2",
-				"is-hexadecimal": "1.0.2"
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
 			}
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
+		},
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"dev": true,
+			"requires": {
+				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"pretty-format": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+			"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
+			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"prompts": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+			"integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.2",
+				"sisteransi": "^1.0.0"
+			}
+		},
+		"psl": {
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
+		},
+		"react-is": {
+			"version": "16.8.5",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+			"integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
+			"dev": true
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"realpath-native": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+			"dev": true,
+			"requires": {
+				"util.promisify": "^1.0.0"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
@@ -181,52 +3604,812 @@
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
+		"request": {
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"extend": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+					"dev": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"rsvp": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"sane": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+			"dev": true,
+			"requires": {
+				"@cnakazawa/watch": "^1.0.3",
+				"anymatch": "^2.0.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
+				"fb-watchman": "^2.0.0",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5"
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sisteransi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"dev": true
+		},
+		"slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+			"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+			"dev": true
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
 		},
 		"state-toggle": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
 			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
 		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"stringify-entities": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
 			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
 			"requires": {
-				"character-entities-html4": "1.1.2",
-				"character-entities-legacy": "1.1.2",
-				"is-alphanumerical": "1.0.2",
-				"is-hexadecimal": "1.0.2"
+				"character-entities-html4": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
 			}
 		},
+		"strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^4.1.0"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
+		},
+		"test-exclude": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^1.0.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
 		"trough": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
-			"integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw=="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"uglify-js": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
+			"integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.19.0",
+				"source-map": "~0.6.1"
+			}
 		},
 		"unherit": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
 			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
 			"requires": {
-				"inherits": "2.0.3",
-				"xtend": "4.0.1"
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
 			}
 		},
 		"unified": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
 			"requires": {
-				"bail": "1.0.3",
-				"extend": "3.0.1",
-				"is-plain-obj": "1.1.0",
-				"trough": "1.0.2",
-				"vfile": "2.3.0",
-				"x-is-string": "0.1.0"
+				"@types/unist": "^2.0.0",
+				"@types/vfile": "^3.0.0",
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^3.0.0",
+				"x-is-string": "^0.1.0"
+			}
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
 			}
 		},
 		"unist-util-is": {
@@ -239,7 +4422,7 @@
 			"resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
 			"integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
 			"requires": {
-				"array-iterate": "1.1.2"
+				"array-iterate": "^1.0.0"
 			}
 		},
 		"unist-util-stringify-position": {
@@ -252,26 +4435,287 @@
 			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
 			"integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
 			"requires": {
-				"unist-util-is": "2.1.2"
+				"unist-util-is": "^2.1.1"
+			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vfile": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
 			"requires": {
-				"is-buffer": "1.1.6",
+				"is-buffer": "^2.0.0",
 				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "1.1.2",
-				"vfile-message": "1.0.1"
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+				}
 			}
 		},
 		"vfile-message": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
-			"integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
 			"requires": {
-				"unist-util-stringify-position": "1.1.2"
+				"unist-util-stringify-position": "^1.1.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
+			"requires": {
+				"makeerror": "1.0.x"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
+		},
+		"whatwg-encoding": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.24"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write-file-atomic": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"ws": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"x-is-string": {
@@ -279,10 +4723,52 @@
 			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
 			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
 		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^4.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
+			}
+		},
+		"yargs-parser": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
 		}
 	}
 }

--- a/packages/curriculum-compiler-string/package.json
+++ b/packages/curriculum-compiler-string/package.json
@@ -4,6 +4,11 @@
   "description": "Compiles Enki Curriculum AST into a markdown string",
   "author": "Nemanja Stojanovic <nemanjacoder@gmail.com>",
   "main": "index.js",
+  "scripts": {
+    "test:watch": "jest --watchAll",
+    "test": "jest --coverage --notify",
+    "test:regex": "npm test -- regexToMatchFile"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/enkidevs/curriculum-processors.git"
@@ -31,10 +36,12 @@
   "dependencies": {
     "@enkidevs/curriculum-helpers": "^2.2.1",
     "@enkidevs/remark-stringify": "^5.1.1",
-    "js-yaml": "^3.11.0",
-    "unified": "^6.1.6"
+    "js-yaml": "^3.13.0",
+    "unified": "^7.1.0"
   },
-  "jest": {
-    "testRegex": "/.*__tests__/.*\\.test.js$"
+  "devDependencies": {
+    "jest": "^24.5.0",
+    "jest-in-case": "^1.0.2",
+    "jsonfile": "^5.0.0"
   }
 }

--- a/packages/curriculum-helpers/jest.config.js
+++ b/packages/curriculum-helpers/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testRegex: '.*/__tests__/.*\\.test.js$',
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/dist/**',
+    '!**/__tests__/**',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+    '!**/*sandbox.js',
+  ],
+};

--- a/packages/curriculum-helpers/package-lock.json
+++ b/packages/curriculum-helpers/package-lock.json
@@ -1,928 +1,972 @@
 {
-	"requires": true,
+	"name": "@enkidevs/curriculum-helpers",
+	"version": "2.2.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-			"integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
 			"requires": {
-				"@babel/highlight": "7.0.0-beta.49"
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+			"integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helpers": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
+			"integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0-beta.49",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-			"integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
 			}
+		},
+		"@babel/parser": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+			"integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+			"dev": true
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+			"integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"dev": true,
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
+			}
+		},
+		"@jest/console": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
+			"integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
+			"dev": true,
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"@types/node": "*",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
+			"integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/reporters": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.5.0",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve-dependencies": "^24.5.0",
+				"jest-runner": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"jest-watcher": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"pirates": "^4.0.1",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"strip-ansi": "^5.0.0"
+			}
+		},
+		"@jest/environment": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
+			"integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
+			"integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
+			"integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-api": "^2.1.1",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"jest-haste-map": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"node-notifier": "^5.2.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
+			"integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/types": "^24.5.0",
+				"@types/istanbul-lib-coverage": "^1.1.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
+			"integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"jest-haste-map": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "2.4.1"
+			}
+		},
+		"@jest/types": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
+			"integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^1.1.0",
+				"@types/yargs": "^12.0.9"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
+			"integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
+			"integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+			"dev": true
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/yargs": {
+			"version": "12.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
+			"dev": true
 		},
 		"abab": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
-			"integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"dev": true
 		},
 		"acorn": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
-			"integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw=="
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-			"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"dev": true,
 			"requires": {
-				"acorn": "5.6.2"
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
 			}
+		},
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"dev": true
 		},
 		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
 			}
-		},
-		"align-text": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
-			}
-		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
 		},
 		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
 		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
-				"color-convert": "1.9.1"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"anymatch": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
 			"requires": {
-				"micromatch": "3.1.10",
-				"normalize-path": "2.1.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					}
-				}
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"append-transform": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
 			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"dev": true,
 			"requires": {
-				"default-require-extensions": "2.0.0"
+				"default-require-extensions": "^2.0.0"
 			}
 		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"requires": {
-				"arr-flatten": "1.1.0"
-			}
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
 		},
 		"array-unique": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
 		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
 		},
 		"async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"dev": true,
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"atob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-			"integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
-		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
-		"babel-core": {
-			"version": "6.26.3",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-generator": "6.26.1",
-				"babel-helpers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-register": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"convert-source-map": "1.5.1",
-				"debug": "2.6.9",
-				"json5": "0.5.1",
-				"lodash": "4.17.10",
-				"minimatch": "3.0.4",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
-				"slash": "1.0.0",
-				"source-map": "0.5.7"
-			}
-		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.10",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
-			}
-		},
-		"babel-helpers": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
-			}
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
 		},
 		"babel-jest": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
-			"integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
+			"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "4.1.6",
-				"babel-preset-jest": "22.4.4"
-			}
-		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"requires": {
-				"babel-runtime": "6.26.0"
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/babel__core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.3.0",
+				"chalk": "^2.4.2",
+				"slash": "^2.0.0"
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
+			"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.10.1",
-				"test-exclude": "4.2.1"
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.0.0",
+				"test-exclude": "^5.0.0"
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
-			"integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ=="
-		},
-		"babel-plugin-syntax-object-rest-spread": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
+			"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+			"dev": true,
+			"requires": {
+				"@types/babel__traverse": "^7.0.6"
+			}
 		},
 		"babel-preset-jest": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
-			"integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
+			"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "22.4.4",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0"
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.3.0"
 			}
-		},
-		"babel-register": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-			"requires": {
-				"babel-core": "6.26.3",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.7",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.10",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
-			},
-			"dependencies": {
-				"source-map-support": {
-					"version": "0.4.18",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-					"requires": {
-						"source-map": "0.5.7"
-					}
-				}
-			}
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "2.5.7",
-				"regenerator-runtime": "0.11.1"
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.10"
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.4",
-				"lodash": "4.17.10"
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.10",
-				"to-fast-properties": "1.0.3"
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"optional": true,
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"braces": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"browser-process-hrtime": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
-			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44="
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
 		},
 		"browser-resolve": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-			"integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"dev": true,
 			"requires": {
 				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
 			}
 		},
 		"bser": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
 		},
 		"buffer-from": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
-		},
-		"builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"cache-base": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			}
 		},
 		"callsites": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+			"dev": true
 		},
 		"camelcase": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-			"optional": true
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+			"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+			"dev": true
 		},
 		"capture-exit": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+			"dev": true,
 			"requires": {
-				"rsvp": "3.6.2"
+				"rsvp": "^4.8.4"
 			}
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-		},
-		"center-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"optional": true,
-			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
-			}
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.4.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"ci-info": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-			"integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
 		"cliui": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-			"optional": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
-				"wordwrap": "0.0.2"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			},
 			"dependencies": {
-				"wordwrap": {
-					"version": "0.0.2",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-					"optional": true
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
 				}
 			}
 		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
 		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"collection-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color-convert": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -930,96 +974,130 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
+		"commander": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"dev": true,
+			"optional": true
+		},
 		"compare-versions": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.2.1.tgz",
-			"integrity": "sha512-2y2nHcopMG/NAyk6vWXlLs86XeM9sik4jmx1tKIgzMi9/RQ2eo758RGpxQO3ErihHmg0RlQITPqgz73y6s7quA=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+			"dev": true
 		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"convert-source-map": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-		},
-		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.3",
-				"shebang-command": "1.2.0",
-				"which": "1.3.1"
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cssom": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-			"integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"dev": true
 		},
 		"cssstyle": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
-			"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+			"integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+			"dev": true,
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"data-urls": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
 			"requires": {
-				"abab": "1.0.4",
-				"whatwg-mimetype": "2.1.0",
-				"whatwg-url": "6.4.1"
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -1027,1259 +1105,844 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-require-extensions": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
 			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"dev": true,
 			"requires": {
-				"strip-bom": "3.0.0"
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"define-properties": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"object-keys": "^1.0.12"
 			}
 		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"detect-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"requires": {
-				"repeating": "2.0.1"
-			}
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"detect-newline": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
 		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"dev": true
 		},
 		"domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
 			"requires": {
-				"webidl-conversions": "4.0.2"
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"optional": true,
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
 			}
 		},
 		"error-ex": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.3",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"dev": true,
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"optional": true
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
 				}
 			}
 		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"estraverse": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"exec-sh": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
-			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-			"requires": {
-				"merge": "1.2.0"
-			}
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+			"dev": true
 		},
 		"execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
 		},
 		"expand-brackets": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"requires": {
-				"fill-range": "2.2.4"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"expect": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
-			"integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
+			"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"jest-diff": "22.4.3",
-				"jest-get-type": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-regex-util": "22.4.3"
+				"@jest/types": "^24.5.0",
+				"ansi-styles": "^3.2.0",
+				"jest-get-type": "^24.3.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0"
 			}
 		},
 		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
 		},
 		"extglob": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
 			}
 		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
 			"requires": {
-				"bser": "2.0.0"
+				"bser": "^2.0.0"
 			}
-		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fileset": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			}
 		},
 		"fill-range": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "3.0.0",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"find-up": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^3.0.0"
 			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"requires": {
-				"for-in": "1.0.2"
-			}
-		},
-		"foreach": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-			"optional": true,
-			"requires": {
-				"nan": "2.10.0",
-				"node-pre-gyp": "0.10.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.5.1",
-					"bundled": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "2.2.4"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.21",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": "2.1.2"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "1.1.11"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"minipass": {
-					"version": "2.2.4",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
-					}
-				},
-				"minizlib": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "2.2.4"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.2.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.10.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.1.10",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.7",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "0.5.1",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.5.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.1.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"yallist": {
-					"version": "3.0.2",
-					"bundled": true
-				}
-			}
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"get-caller-file": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
-			}
-		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
-			}
-		},
-		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"requires": {
-				"is-glob": "2.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"dev": true
 		},
 		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
 		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
 		},
 		"handlebars": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"dev": true,
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": "1.0.1"
-					}
-				}
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
 			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "2.1.1"
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			}
 		},
 		"has-values": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
 		},
-		"home-or-tmp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
-			}
-		},
 		"hosted-git-info": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
 			"requires": {
-				"whatwg-encoding": "1.0.3"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.2"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"import-local": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+			"dev": true,
 			"requires": {
-				"pkg-dir": "2.0.0",
-				"resolve-cwd": "2.0.0"
+				"pkg-dir": "^3.0.0",
+				"resolve-cwd": "^2.0.0"
 			}
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"requires": {
-				"builtin-modules": "1.1.1"
-			}
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
 		},
 		"is-ci": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
 			"requires": {
-				"ci-info": "1.1.3"
+				"ci-info": "^2.0.0"
 			}
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
 				}
-			}
-		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"requires": {
-				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-		},
-		"is-extglob": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-generator-fn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
-		},
-		"is-glob": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"requires": {
-				"is-extglob": "1.0.0"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+			"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+			"dev": true
 		},
 		"is-number": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
-			}
-		},
-		"is-odd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"requires": {
-				"is-number": "4.0.0"
+				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
 				}
 			}
 		},
@@ -2287,616 +1950,704 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
+				"isobject": "^3.0.1"
 			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
-				"has": "1.0.3"
+				"has": "^1.0.1"
 			}
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-symbol": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"requires": {
-				"isarray": "1.0.0"
-			}
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
 		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-api": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
-			"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
+			"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+			"dev": true,
 			"requires": {
-				"async": "2.6.1",
-				"compare-versions": "3.2.1",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.2.0",
-				"istanbul-lib-hook": "1.2.1",
-				"istanbul-lib-instrument": "1.10.1",
-				"istanbul-lib-report": "1.1.4",
-				"istanbul-lib-source-maps": "1.2.5",
-				"istanbul-reports": "1.3.0",
-				"js-yaml": "3.12.0",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"istanbul-lib-source-maps": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
-					"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
-					"requires": {
-						"debug": "3.1.0",
-						"istanbul-lib-coverage": "1.2.0",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.2",
-						"source-map": "0.5.7"
-					}
-				}
+				"async": "^2.6.1",
+				"compare-versions": "^3.2.1",
+				"fileset": "^2.0.3",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.1.0",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.1",
+				"js-yaml": "^3.12.0",
+				"make-dir": "^1.3.0",
+				"minimatch": "^3.0.4",
+				"once": "^1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-			"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"dev": true
 		},
 		"istanbul-lib-hook": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
-			"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+			"dev": true,
 			"requires": {
-				"append-transform": "1.0.0"
+				"append-transform": "^1.0.0"
 			}
 		},
 		"istanbul-lib-instrument": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-			"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+			"dev": true,
 			"requires": {
-				"babel-generator": "6.26.1",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"semver": "5.5.0"
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.3",
+				"semver": "^5.5.0"
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
-			"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+			"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"supports-color": "^6.0.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-				},
 				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-			"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+			"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+			"dev": true,
 			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.2.0",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"source-map": "0.5.7"
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"rimraf": "^2.6.2",
+				"source-map": "^0.6.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
-			"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+			"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+			"dev": true,
 			"requires": {
-				"handlebars": "4.0.11"
+				"handlebars": "^4.1.0"
 			}
 		},
 		"jest": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
-			"integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
+			"integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
+			"dev": true,
 			"requires": {
-				"import-local": "1.0.0",
-				"jest-cli": "22.4.4"
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.5.0"
 			},
 			"dependencies": {
 				"jest-cli": {
-					"version": "22.4.4",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
-					"integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
+					"version": "24.5.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
+					"integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
+					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.1.0",
-						"chalk": "2.4.1",
-						"exit": "0.1.2",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"import-local": "1.0.0",
-						"is-ci": "1.1.0",
-						"istanbul-api": "1.3.1",
-						"istanbul-lib-coverage": "1.2.0",
-						"istanbul-lib-instrument": "1.10.1",
-						"istanbul-lib-source-maps": "1.2.3",
-						"jest-changed-files": "22.4.3",
-						"jest-config": "22.4.4",
-						"jest-environment-jsdom": "22.4.3",
-						"jest-get-type": "22.4.3",
-						"jest-haste-map": "22.4.3",
-						"jest-message-util": "22.4.3",
-						"jest-regex-util": "22.4.3",
-						"jest-resolve-dependencies": "22.4.3",
-						"jest-runner": "22.4.4",
-						"jest-runtime": "22.4.4",
-						"jest-snapshot": "22.4.3",
-						"jest-util": "22.4.3",
-						"jest-validate": "22.4.4",
-						"jest-worker": "22.4.3",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.2.1",
-						"realpath-native": "1.0.0",
-						"rimraf": "2.6.2",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.3.1",
-						"yargs": "10.1.2"
+						"@jest/core": "^24.5.0",
+						"@jest/test-result": "^24.5.0",
+						"@jest/types": "^24.5.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.5.0",
+						"jest-util": "^24.5.0",
+						"jest-validate": "^24.5.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^12.0.2"
 					}
 				}
 			}
 		},
 		"jest-changed-files": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
-			"integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
+			"integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
+			"dev": true,
 			"requires": {
-				"throat": "4.1.0"
+				"@jest/types": "^24.5.0",
+				"execa": "^1.0.0",
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
-			"integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
+			"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"glob": "7.1.2",
-				"jest-environment-jsdom": "22.4.3",
-				"jest-environment-node": "22.4.3",
-				"jest-get-type": "22.4.3",
-				"jest-jasmine2": "22.4.4",
-				"jest-regex-util": "22.4.3",
-				"jest-resolve": "22.4.3",
-				"jest-util": "22.4.3",
-				"jest-validate": "22.4.4",
-				"pretty-format": "22.4.3"
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-jest": "^24.5.0",
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^24.5.0",
+				"jest-environment-node": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.5.0",
+				"realpath-native": "^1.1.0"
 			}
 		},
 		"jest-diff": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-			"integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
+			"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"diff": "3.5.0",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
-			"integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"dev": true,
 			"requires": {
-				"detect-newline": "2.1.0"
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
+			"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
-			"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
+			"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+			"dev": true,
 			"requires": {
-				"jest-mock": "22.4.3",
-				"jest-util": "22.4.3",
-				"jsdom": "11.11.0"
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
-			"integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
+			"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+			"dev": true,
 			"requires": {
-				"jest-mock": "22.4.3",
-				"jest-util": "22.4.3"
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0"
 			}
 		},
 		"jest-get-type": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+			"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
-			"integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
+			"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+			"dev": true,
 			"requires": {
-				"fb-watchman": "2.0.0",
-				"graceful-fs": "4.1.11",
-				"jest-docblock": "22.4.3",
-				"jest-serializer": "22.4.3",
-				"jest-worker": "22.4.3",
-				"micromatch": "2.3.11",
-				"sane": "2.5.2"
+				"@jest/types": "^24.5.0",
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"invariant": "^2.2.4",
+				"jest-serializer": "^24.4.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"micromatch": "^3.1.10",
+				"sane": "^4.0.3"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
-			"integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
+			"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"co": "4.6.0",
-				"expect": "22.4.3",
-				"graceful-fs": "4.1.11",
-				"is-generator-fn": "1.0.0",
-				"jest-diff": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-snapshot": "22.4.3",
-				"jest-util": "22.4.3",
-				"source-map-support": "0.5.6"
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^24.5.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0",
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
-			"integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
+			"integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
+			"dev": true,
 			"requires": {
-				"pretty-format": "22.4.3"
+				"pretty-format": "^24.5.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-			"integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
+			"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-get-type": "22.4.3",
-				"pretty-format": "22.4.3"
+				"chalk": "^2.0.1",
+				"jest-diff": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
-			"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
+			"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+			"dev": true,
 			"requires": {
-				"@babel/code-frame": "7.0.0-beta.49",
-				"chalk": "2.4.1",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0",
-				"stack-utils": "1.0.1"
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
+				"stack-utils": "^1.0.1"
 			}
 		},
 		"jest-mock": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-			"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
+			"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"dev": true
 		},
 		"jest-regex-util": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-			"integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg=="
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"dev": true
 		},
 		"jest-resolve": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
-			"integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
+			"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+			"dev": true,
 			"requires": {
-				"browser-resolve": "1.11.2",
-				"chalk": "2.4.1"
+				"@jest/types": "^24.5.0",
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"jest-pnp-resolver": "^1.2.1",
+				"realpath-native": "^1.1.0"
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
-			"integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
+			"integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
+			"dev": true,
 			"requires": {
-				"jest-regex-util": "22.4.3"
+				"@jest/types": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.5.0"
 			}
 		},
 		"jest-runner": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
-			"integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
+			"integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
+			"dev": true,
 			"requires": {
-				"exit": "0.1.2",
-				"jest-config": "22.4.4",
-				"jest-docblock": "22.4.3",
-				"jest-haste-map": "22.4.3",
-				"jest-jasmine2": "22.4.4",
-				"jest-leak-detector": "22.4.3",
-				"jest-message-util": "22.4.3",
-				"jest-runtime": "22.4.4",
-				"jest-util": "22.4.3",
-				"jest-worker": "22.4.3",
-				"throat": "4.1.0"
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.4.2",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-docblock": "^24.3.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-leak-detector": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
-			"integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
+			"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+			"dev": true,
 			"requires": {
-				"babel-core": "6.26.3",
-				"babel-jest": "22.4.4",
-				"babel-plugin-istanbul": "4.1.6",
-				"chalk": "2.4.1",
-				"convert-source-map": "1.5.1",
-				"exit": "0.1.2",
-				"graceful-fs": "4.1.11",
-				"jest-config": "22.4.4",
-				"jest-haste-map": "22.4.3",
-				"jest-regex-util": "22.4.3",
-				"jest-resolve": "22.4.3",
-				"jest-util": "22.4.3",
-				"jest-validate": "22.4.4",
-				"json-stable-stringify": "1.0.1",
-				"micromatch": "2.3.11",
-				"realpath-native": "1.0.0",
-				"slash": "1.0.0",
-				"strip-bom": "3.0.0",
-				"write-file-atomic": "2.3.0",
-				"yargs": "10.1.2"
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/yargs": "^12.0.2",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"strip-bom": "^3.0.0",
+				"yargs": "^12.0.2"
 			}
 		},
 		"jest-serializer": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-			"integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw=="
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
-			"integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
+			"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-diff": "22.4.3",
-				"jest-matcher-utils": "22.4.3",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"pretty-format": "22.4.3"
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"expect": "^24.5.0",
+				"jest-diff": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^24.5.0",
+				"semver": "^5.5.0"
 			}
 		},
 		"jest-util": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
-			"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
+			"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+			"dev": true,
 			"requires": {
-				"callsites": "2.0.0",
-				"chalk": "2.4.1",
-				"graceful-fs": "4.1.11",
-				"is-ci": "1.1.0",
-				"jest-message-util": "22.4.3",
-				"mkdirp": "0.5.1",
-				"source-map": "0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
+				"@jest/console": "^24.3.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"callsites": "^3.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"jest-validate": {
-			"version": "22.4.4",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
-			"integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+			"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"jest-config": "22.4.4",
-				"jest-get-type": "22.4.3",
-				"leven": "2.1.0",
-				"pretty-format": "22.4.3"
+				"@jest/types": "^24.5.0",
+				"camelcase": "^5.0.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
+			"integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"@types/yargs": "^12.0.9",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"jest-util": "^24.5.0",
+				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
-			"integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
+			"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+			"dev": true,
 			"requires": {
-				"merge-stream": "1.0.1"
+				"@types/node": "*",
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"optional": true
+			"dev": true
 		},
 		"jsdom": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
-			"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"dev": true,
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "5.6.2",
-				"acorn-globals": "4.1.0",
-				"array-equal": "1.0.0",
-				"cssom": "0.3.2",
-				"cssstyle": "0.3.1",
-				"data-urls": "1.0.0",
-				"domexception": "1.0.1",
-				"escodegen": "1.9.1",
-				"html-encoding-sniffer": "1.0.2",
-				"left-pad": "1.3.0",
-				"nwsapi": "2.0.2",
+				"abab": "^2.0.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.9.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
 				"parse5": "4.0.0",
-				"pn": "1.1.0",
-				"request": "2.87.0",
-				"request-promise-native": "1.0.5",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.4.2",
-				"w3c-hr-time": "1.0.1",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-mimetype": "2.1.0",
-				"whatwg-url": "6.4.1",
-				"ws": "4.1.0",
-				"xml-name-validator": "3.0.0"
+				"pn": "^1.1.0",
+				"request": "^2.87.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.4",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
+				"xml-name-validator": "^3.0.0"
 			}
 		},
 		"jsesc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-		},
-		"json-stable-stringify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"requires": {
-				"jsonify": "0.0.0"
-			}
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json5": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -2905,222 +2656,227 @@
 			}
 		},
 		"kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"requires": {
-				"is-buffer": "1.1.6"
-			}
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
 		},
-		"lazy-cache": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-			"optional": true
+		"kleur": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
+			"integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==",
+			"dev": true
 		},
 		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"dev": true,
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^2.0.0"
 			}
 		},
 		"left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
 		},
 		"leven": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
 		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				}
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
-			"version": "4.17.10",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
 		},
 		"loose-envify": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
-		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pify": "^3.0.0"
 			}
 		},
 		"makeerror": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
+			}
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
 			}
 		},
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
-		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
 		},
 		"mem": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+			"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+			"dev": true,
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
 			}
-		},
-		"merge": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
 		},
 		"merge-stream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.6"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			}
 		},
 		"mime-db": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.18",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"dev": true,
 			"requires": {
-				"mime-db": "1.33.0"
+				"mime-db": "~1.38.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+			"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -3129,119 +2885,134 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
 			}
 		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"nan": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-			"optional": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"nanomatch": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
 		},
 		"node-int64": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"dev": true,
 			"requires": {
-				"growly": "1.3.0",
-				"semver": "5.5.0",
-				"shellwords": "0.1.1",
-				"which": "1.3.1"
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.6.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.0",
-				"validate-npm-package-license": "3.0.3"
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwsapi": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.2.tgz",
-			"integrity": "sha512-wAvMV1QgoYPvqfcAmX1M86SyZA3SnNT6UNvjqO/pKHjIZzhMpPHjCTOWdOfkmUknjnvjDq09wDiBaHAzXSLiSA=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+			"integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+			"dev": true
 		},
 		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -3252,882 +3023,626 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
 		},
 		"object-keys": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+			"integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
+				"isobject": "^3.0.0"
 			}
 		},
 		"object.getownpropertydescriptors": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.12.0"
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
 			}
 		},
 		"object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				}
+				"isobject": "^3.0.1"
 			}
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
 			"requires": {
-				"minimist": "0.0.8",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
 			}
 		},
 		"optionator": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
 				}
 			}
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-		},
 		"os-locale": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"dev": true,
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
 			}
 		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-is-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"dev": true
 		},
 		"p-limit": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"dev": true,
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
 			"requires": {
-				"p-limit": "1.3.0"
+				"p-limit": "^2.0.0"
 			}
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
 		},
 		"p-try": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
-			}
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+			"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+			"dev": true
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
 		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"pify": "^3.0.0"
 			}
 		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
 		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"node-modules-regexp": "^1.0.0"
 			}
 		},
 		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^3.0.0"
 			}
 		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"pretty-format": {
-			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-			"integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+			"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0",
-				"ansi-styles": "3.2.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				}
+				"@jest/types": "^24.5.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
 			}
-		},
-		"private": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
 		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		"prompts": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+			"integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.2",
+				"sisteransi": "^1.0.0"
+			}
 		},
 		"psl": {
-			"version": "1.1.27",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.27.tgz",
-			"integrity": "sha512-J8tJX5tAeEp9tQTI2w2aMZ6V1INuU4JmNaNPRuHAqjjVq3ZJ+jV3+tcT3ncgTnBxvwJy740IB/WZrxFus2VdMA=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
 		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
 		},
-		"randomatic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-			"requires": {
-				"is-number": "4.0.0",
-				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
+		"react-is": {
+			"version": "16.8.5",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+			"integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
+			"dev": true
 		},
 		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+			"dev": true,
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
-					}
-				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-					"requires": {
-						"pinkie-promise": "2.0.1"
-					}
-				}
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.2",
-				"string_decoder": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"realpath-native": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
-			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+			"dev": true,
 			"requires": {
-				"util.promisify": "1.0.0"
-			}
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
 		},
 		"repeat-element": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"requires": {
-				"is-finite": "1.0.2"
-			}
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"request": {
-			"version": "2.87.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.7.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.2",
-				"safe-buffer": "5.1.2",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.2.1"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"punycode": {
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
 				},
 				"tough-cookie": {
-					"version": "2.3.4",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-					"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
 					"requires": {
-						"punycode": "1.4.1"
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
 					}
 				}
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"dev": true,
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.1",
-				"stealthy-require": "1.1.1",
-				"tough-cookie": "2.4.2"
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
 			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"resolve": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
 		},
 		"resolve-cwd": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			}
 		},
 		"resolve-from": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
 		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
 		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-		},
-		"right-align": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"optional": true,
-			"requires": {
-				"align-text": "0.1.4"
-			}
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.1.3"
 			}
 		},
 		"rsvp": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+			"dev": true,
 			"requires": {
-				"anymatch": "2.0.0",
-				"capture-exit": "1.2.0",
-				"exec-sh": "0.2.1",
-				"fb-watchman": "2.0.0",
-				"fsevents": "1.2.4",
-				"micromatch": "3.1.10",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.18.0"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
+				"@cnakazawa/watch": "^1.0.3",
+				"anymatch": "^2.0.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
+				"fb-watchman": "^2.0.0",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5"
 			}
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"semver": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -4136,60 +3651,80 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sisteransi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"dev": true
 		},
 		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.2",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
 				}
 			}
 		},
@@ -4197,55 +3732,50 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -4253,125 +3783,144 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
 			"requires": {
-				"atob": "2.1.1",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+			"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+			"dev": true,
 			"requires": {
-				"buffer-from": "1.1.0",
-				"source-map": "0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
 		},
 		"spdx-correct": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.0"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+			"dev": true
 		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-			"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"safer-buffer": "2.1.2",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
-			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
 		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -4379,508 +3928,273 @@
 		"stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
 		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
 			"requires": {
-				"astral-regex": "1.0.0",
-				"strip-ansi": "4.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
 			"requires": {
-				"ansi-regex": "3.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-				}
+				"ansi-regex": "^4.1.0"
 			}
 		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
 		},
 		"test-exclude": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-			"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "3.1.10",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-					"requires": {
-						"arr-flatten": "1.1.0",
-						"array-unique": "0.3.2",
-						"extend-shallow": "2.0.1",
-						"fill-range": "4.0.0",
-						"isobject": "3.0.1",
-						"repeat-element": "1.1.2",
-						"snapdragon": "0.8.2",
-						"snapdragon-node": "2.1.1",
-						"split-string": "3.1.0",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"expand-brackets": {
-					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-					"requires": {
-						"debug": "2.6.9",
-						"define-property": "0.2.5",
-						"extend-shallow": "2.0.1",
-						"posix-character-classes": "0.1.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-							"requires": {
-								"is-descriptor": "0.1.6"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						},
-						"is-accessor-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-data-descriptor": {
-							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-							"requires": {
-								"kind-of": "3.2.2"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"requires": {
-										"is-buffer": "1.1.6"
-									}
-								}
-							}
-						},
-						"is-descriptor": {
-							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-							"requires": {
-								"is-accessor-descriptor": "0.1.6",
-								"is-data-descriptor": "0.1.4",
-								"kind-of": "5.1.0"
-							}
-						},
-						"kind-of": {
-							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-						}
-					}
-				},
-				"extglob": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-					"requires": {
-						"array-unique": "0.3.2",
-						"define-property": "1.0.0",
-						"expand-brackets": "2.1.4",
-						"extend-shallow": "2.0.1",
-						"fragment-cache": "0.2.1",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					},
-					"dependencies": {
-						"define-property": {
-							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-							"requires": {
-								"is-descriptor": "1.0.2"
-							}
-						},
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-number": "3.0.0",
-						"repeat-string": "1.6.1",
-						"to-regex-range": "2.1.1"
-					},
-					"dependencies": {
-						"extend-shallow": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-							"requires": {
-								"is-extendable": "0.1.1"
-							}
-						}
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "3.2.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"requires": {
-								"is-buffer": "1.1.6"
-							}
-						}
-					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-				},
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				},
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"requires": {
-						"arr-diff": "4.0.0",
-						"array-unique": "0.3.2",
-						"braces": "2.3.2",
-						"define-property": "2.0.2",
-						"extend-shallow": "3.0.2",
-						"extglob": "2.0.4",
-						"fragment-cache": "0.2.1",
-						"kind-of": "6.0.2",
-						"nanomatch": "1.2.9",
-						"object.pick": "1.3.0",
-						"regex-not": "1.0.2",
-						"snapdragon": "0.8.2",
-						"to-regex": "3.0.2"
-					}
-				}
+				"arrify": "^1.0.1",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^1.0.1"
 			}
 		},
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
 		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
 		},
 		"to-fast-properties": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				}
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			}
 		},
 		"tough-cookie": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
-			"integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
 			"requires": {
-				"psl": "1.1.27",
-				"punycode": "1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
 			"requires": {
-				"punycode": "2.1.1"
+				"punycode": "^2.1.0"
 			}
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.2"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"optional": true
+			"dev": true
 		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"uglify-js": {
-			"version": "2.8.29",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
+			"integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
-			},
-			"dependencies": {
-				"yargs": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-					"optional": true,
-					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
-						"window-size": "0.1.0"
-					}
-				}
+				"commander": "~2.19.0",
+				"source-map": "~0.6.1"
 			}
-		},
-		"uglify-to-browserify": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"optional": true
 		},
 		"union-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
-			}
-		},
-		"unist-util-assert": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-assert/-/unist-util-assert-1.0.2.tgz",
-			"integrity": "sha512-HbAeG1smDbSirJySgqZ7nbKdygmuL0s/1MMPXaHrChWMKueYuRHfk5R8EmlDV0vPfP8uLwazrvpu0ZkVYZD/xg==",
-			"requires": {
-				"x-is-array": "0.1.0",
-				"x-is-object": "0.1.0"
 			}
 		},
 		"unist-util-map": {
@@ -4888,32 +4202,35 @@
 			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-1.0.4.tgz",
 			"integrity": "sha512-Qv68pQz05hQbjPI+TubZQI5XII5DScRVWaKNc6+qfmHaFGxaGUbkV8i++mM2nk7XgwXE+vei99d/Q2d1tMA3EQ==",
 			"requires": {
-				"object-assign": "4.1.1"
+				"object-assign": "^4.0.1"
 			}
 		},
 		"unset-value": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -4923,190 +4240,189 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
 				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
 		},
 		"use": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"requires": {
-				"kind-of": "6.0.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-				}
-			}
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"util.promisify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"object.getownpropertydescriptors": "2.0.3"
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
 		"uuid": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
 		},
 		"validate-npm-package-license": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"w3c-hr-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "0.1.2"
+				"browser-process-hrtime": "^0.1.2"
 			}
 		},
 		"walker": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
 			"requires": {
-				"makeerror": "1.0.11"
-			}
-		},
-		"watch": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-			"requires": {
-				"exec-sh": "0.2.1",
-				"minimist": "1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-				}
+				"makeerror": "1.0.x"
 			}
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
 		},
 		"whatwg-encoding": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-			"integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "0.4.24"
 			}
 		},
 		"whatwg-mimetype": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
 		},
 		"whatwg-url": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
-			"integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"dev": true,
 			"requires": {
-				"lodash.sortby": "4.7.0",
-				"tr46": "1.0.1",
-				"webidl-conversions": "4.0.2"
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
-		"window-size": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-			"optional": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
 		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}
@@ -5114,96 +4430,69 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"ws": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+			"dev": true,
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.2"
+				"async-limiter": "~1.0.0"
 			}
-		},
-		"x-is-array": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz",
-			"integrity": "sha1-3lIBcdR7P0FvVYfWKbidJrEtwp0="
-		},
-		"x-is-object": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/x-is-object/-/x-is-object-0.1.0.tgz",
-			"integrity": "sha1-j5SW0Wht9IcVYJbnbKmUTvwVv+w="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
 		},
 		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-		},
-		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
 		},
 		"yargs": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-			"integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"dev": true,
 			"requires": {
-				"cliui": "4.1.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "8.1.0"
-			},
-			"dependencies": {
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"requires": {
-						"string-width": "2.1.1",
-						"strip-ansi": "4.0.0",
-						"wrap-ansi": "2.1.0"
-					}
-				}
+				"cliui": "^4.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
 			}
 		},
 		"yargs-parser": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				}
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/packages/curriculum-helpers/package.json
+++ b/packages/curriculum-helpers/package.json
@@ -4,6 +4,11 @@
   "description": "Helpers for parsing/transforming/compiling Enki Curriculum from and to different formats",
   "author": "Nemanja Stojanovic <nemanjacoder@gmail.com>",
   "main": "index.js",
+  "scripts": {
+    "test:watch": "jest --watchAll",
+    "test": "jest --coverage --notify",
+    "test:regex": "npm test -- regexToMatchFile"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/enkidevs/curriculum-processors.git"
@@ -24,13 +29,9 @@
     "lib"
   ],
   "dependencies": {
-    "unist-util-assert": "^1.0.1",
     "unist-util-map": "^1.0.3"
   },
   "devDependencies": {
-    "jest": "^22.4.2"
-  },
-  "jest": {
-    "testRegex": "/.*__tests__/.*\\.test.js$"
+    "jest": "^24.5.0"
   }
 }

--- a/packages/curriculum-parser-json/.vscode/launch.json
+++ b/packages/curriculum-parser-json/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Sandbox",
+      "program": "${workspaceFolder}/index.sandbox.js"
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${relativeFile}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    }
+  ]
+}

--- a/packages/curriculum-parser-json/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-parser-json/__tests__/fixtures/insight/sample/ast.json
@@ -57,6 +57,7 @@
             {
               "type": "linkReference",
               "identifier": "1",
+              "label": "1",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -77,6 +78,7 @@
             {
               "type": "linkReference",
               "identifier": "2",
+              "label": "2",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -95,11 +97,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -115,7 +117,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -145,6 +147,7 @@
             {
               "type": "linkReference",
               "identifier": "3",
+              "label": "3",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -161,6 +164,7 @@
         },
         {
           "type": "code",
+          "meta": null,
           "lang": "javascript",
           "value": "console.log('sample code')"
         }
@@ -177,6 +181,7 @@
             {
               "type": "linkReference",
               "identifier": "1: paragraph",
+              "label": "1: Paragraph",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -197,6 +202,7 @@
             {
               "type": "linkReference",
               "identifier": "2: list",
+              "label": "2: List",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -217,6 +223,7 @@
             {
               "type": "linkReference",
               "identifier": "3: code",
+              "label": "3: Code",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -233,6 +240,7 @@
         },
         {
           "type": "code",
+          "meta": null,
           "lang": "javascript",
           "value": "var x = 10"
         }
@@ -274,11 +282,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -295,7 +303,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -312,7 +320,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -329,7 +337,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -376,11 +384,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -397,7 +405,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -414,7 +422,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -461,11 +469,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -482,7 +490,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -504,7 +512,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -525,7 +533,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {

--- a/packages/curriculum-parser-json/jest.config.js
+++ b/packages/curriculum-parser-json/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testRegex: '.*/__tests__/.*\\.test.js$',
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/dist/**',
+    '!**/__tests__/**',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+    '!**/*sandbox.js',
+  ],
+};

--- a/packages/curriculum-parser-json/package-lock.json
+++ b/packages/curriculum-parser-json/package-lock.json
@@ -1,13 +1,1337 @@
 {
-	"requires": true,
+	"name": "@enkidevs/curriculum-parser-json",
+	"version": "3.1.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+			"integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helpers": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
+			"integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+			"integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+			"dev": true
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+			"integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"dev": true,
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
+			}
+		},
+		"@enkidevs/curriculum-helpers": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-2.2.1.tgz",
+			"integrity": "sha512-wO3TWNR9gdNooG2IYn2YFgY8WspyOWP6KBF8tidkP4UwAka+/aDaKgnV2nZfdfwEs5SVY++StqQWto3Z/mtFbQ==",
+			"requires": {
+				"unist-util-assert": "^1.0.1",
+				"unist-util-map": "^1.0.3"
+			}
+		},
+		"@enkidevs/curriculum-parser-markdown": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-parser-markdown/-/curriculum-parser-markdown-3.1.1.tgz",
+			"integrity": "sha512-UAINQwN6xdf17kyCxiYcGpu6iFsoXoumSSYD+XyV7MslPBYYjn3UHfiNqOJJ5E4XgLKXuN9NB+5Jk5pErTQ8eQ==",
+			"requires": {
+				"@enkidevs/curriculum-helpers": "^2.2.1",
+				"decode-uri-component": "^0.2.0",
+				"js-yaml": "^3.11.0",
+				"remark-frontmatter": "^1.2.0",
+				"remark-parse": "^5.0.0",
+				"unified": "^6.1.6",
+				"unist-builder": "^1.0.2",
+				"unist-util-map": "^1.0.3",
+				"unist-util-visit": "^1.3.0"
+			}
+		},
+		"@jest/console": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
+			"integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
+			"dev": true,
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"@types/node": "*",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
+			"integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/reporters": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.5.0",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve-dependencies": "^24.5.0",
+				"jest-runner": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"jest-watcher": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"pirates": "^4.0.1",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"strip-ansi": "^5.0.0"
+			}
+		},
+		"@jest/environment": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
+			"integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
+			"integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
+			"integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-api": "^2.1.1",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"jest-haste-map": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"node-notifier": "^5.2.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
+			"integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/types": "^24.5.0",
+				"@types/istanbul-lib-coverage": "^1.1.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
+			"integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"jest-haste-map": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "2.4.1"
+			}
+		},
+		"@jest/types": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
+			"integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^1.1.0",
+				"@types/yargs": "^12.0.9"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
+			"integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
+			"integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+			"dev": true
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/yargs": {
+			"version": "12.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
+			"dev": true
+		},
+		"abab": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
+			}
+		},
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^2.0.0"
+			}
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
+		},
+		"babel-jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
+			"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+			"dev": true,
+			"requires": {
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/babel__core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.3.0",
+				"chalk": "^2.4.2",
+				"slash": "^2.0.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
+			"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.0.0",
+				"test-exclude": "^5.0.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
+			"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+			"dev": true,
+			"requires": {
+				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
+			"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.3.0"
+			}
+		},
+		"bail": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
+		},
+		"browser-resolve": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"dev": true,
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
+		"callsites": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+			"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+			"dev": true
+		},
+		"capture-exit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+			"dev": true,
+			"requires": {
+				"rsvp": "^4.8.4"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"character-entities": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
+		},
+		"character-entities-legacy": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
+		},
+		"character-reference-invalid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
+		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collapse-white-space": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
+			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"dev": true,
+			"optional": true
+		},
+		"compare-versions": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"cssom": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+			"integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+			"dev": true,
+			"requires": {
+				"cssom": "0.3.x"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"dev": true
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"dev": true,
+			"requires": {
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -15,31 +1339,3466 @@
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
-		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"exec-sh": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+			"dev": true
+		},
+		"execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.1"
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"expect": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
+			"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-styles": "^3.2.0",
+				"jest-get-type": "^24.3.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0"
+			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fault": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
+			"integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
+			"requires": {
+				"format": "^0.2.2"
+			}
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
+			"requires": {
+				"bser": "^2.0.0"
+			}
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
+			}
+		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^3.0.0"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "^1.0.1"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"import-local": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^3.0.0",
+				"resolve-cwd": "^2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"invert-kv": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"dev": true
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-alphabetical": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
+		},
+		"is-alphanumerical": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+			"requires": {
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
+		"is-decimal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-generator-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+			"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+			"dev": true
+		},
+		"is-hexadecimal": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
+		"is-whitespace-character": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
+			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-word-character": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
+			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA=="
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"istanbul-api": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
+			"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+			"dev": true,
+			"requires": {
+				"async": "^2.6.1",
+				"compare-versions": "^3.2.1",
+				"fileset": "^2.0.3",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.1.0",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.1",
+				"js-yaml": "^3.12.0",
+				"make-dir": "^1.3.0",
+				"minimatch": "^3.0.4",
+				"once": "^1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+			"dev": true,
+			"requires": {
+				"append-transform": "^1.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.3",
+				"semver": "^5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+			"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"supports-color": "^6.0.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+			"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"rimraf": "^2.6.2",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+			"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+			"dev": true,
+			"requires": {
+				"handlebars": "^4.1.0"
+			}
+		},
+		"jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
+			"integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
+			"dev": true,
+			"requires": {
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.5.0"
+			},
+			"dependencies": {
+				"jest-cli": {
+					"version": "24.5.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
+					"integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^24.5.0",
+						"@jest/test-result": "^24.5.0",
+						"@jest/types": "^24.5.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.5.0",
+						"jest-util": "^24.5.0",
+						"jest-validate": "^24.5.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^12.0.2"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
+			"integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"execa": "^1.0.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-config": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
+			"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-jest": "^24.5.0",
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^24.5.0",
+				"jest-environment-node": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.5.0",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-diff": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
+			"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"dev": true,
+			"requires": {
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
+			"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
+			"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jsdom": "^11.5.1"
+			}
+		},
+		"jest-environment-node": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
+			"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+			"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+			"dev": true
+		},
+		"jest-haste-map": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
+			"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"invariant": "^2.2.4",
+				"jest-serializer": "^24.4.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"micromatch": "^3.1.10",
+				"sane": "^4.0.3"
+			}
+		},
+		"jest-in-case": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/jest-in-case/-/jest-in-case-1.0.2.tgz",
+			"integrity": "sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=",
+			"dev": true
+		},
+		"jest-jasmine2": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
+			"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^24.5.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
+			"integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
+			"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"jest-diff": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
+			"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
+			"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"dev": true
+		},
+		"jest-regex-util": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
+			"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"jest-pnp-resolver": "^1.2.1",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
+			"integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.5.0"
+			}
+		},
+		"jest-runner": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
+			"integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.4.2",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-docblock": "^24.3.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-leak-detector": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
+			"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/yargs": "^12.0.2",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"strip-bom": "^3.0.0",
+				"yargs": "^12.0.2"
+			}
+		},
+		"jest-serializer": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"dev": true
+		},
+		"jest-snapshot": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
+			"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"expect": "^24.5.0",
+				"jest-diff": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^24.5.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"jest-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
+			"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"callsites": "^3.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"jest-validate": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+			"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"camelcase": "^5.0.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
+			"integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"@types/yargs": "^12.0.9",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"jest-util": "^24.5.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"jest-worker": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
+			"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"jsdom": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.9.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
+				"parse5": "4.0.0",
+				"pn": "^1.1.0",
+				"request": "^2.87.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.4",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"json5": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
+		"jsonfile": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+			"integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^0.1.2"
+			}
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
+			"integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==",
+			"dev": true
+		},
+		"lcid": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"dev": true,
+			"requires": {
+				"invert-kv": "^2.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
+			"requires": {
+				"tmpl": "1.0.x"
+			}
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"markdown-escapes": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
+			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
+		},
+		"mem": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+			"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+			"dev": true,
+			"requires": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			}
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
+		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			}
+		},
+		"mime-db": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"dev": true,
+			"requires": {
+				"mime-db": "~1.38.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+			"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
+		},
+		"node-notifier": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"dev": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "^2.0.0"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"nwsapi": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+			"integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+			"integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"dev": true,
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			}
+		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-is-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"dev": true,
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
+		},
+		"p-try": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+			"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+			"dev": true
+		},
+		"parse-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
+			"integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
+			"requires": {
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
+		},
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"dev": true,
+			"requires": {
+				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"pretty-format": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+			"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
+			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"prompts": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+			"integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.2",
+				"sisteransi": "^1.0.0"
+			}
+		},
+		"psl": {
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
+		},
+		"react-is": {
+			"version": "16.8.5",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+			"integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
+			"dev": true
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"realpath-native": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+			"dev": true,
+			"requires": {
+				"util.promisify": "^1.0.0"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"remark-frontmatter": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.1.tgz",
+			"integrity": "sha512-Zj/fDMYnSVgMCeKp8fXIhtMoZq4G6E1dnwfMoO8fVXrm/+oVSiN8YMREtwN2cctgK9EsnYSeS1ExX2hcX/fE1A==",
+			"requires": {
+				"fault": "^1.0.1",
+				"xtend": "^4.0.1"
+			}
+		},
+		"remark-parse": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+			"requires": {
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^1.1.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"trim": "0.0.1",
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^1.0.0",
+				"vfile-location": "^2.0.0",
+				"xtend": "^4.0.1"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"replace-ext": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+		},
+		"request": {
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"rsvp": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"sane": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+			"dev": true,
+			"requires": {
+				"@cnakazawa/watch": "^1.0.3",
+				"anymatch": "^2.0.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
+				"fb-watchman": "^2.0.0",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5"
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sisteransi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"dev": true
+		},
+		"slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+			"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+			"dev": true
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
-		"unist-builder": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
-			"integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
+		"sshpk": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
+		},
+		"state-toggle": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
+			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^4.1.0"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
+		},
+		"test-exclude": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^1.0.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"trim": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"trim-trailing-lines": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
+		},
+		"trough": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw=="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"uglify-js": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
+			"integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.19.0",
+				"source-map": "~0.6.1"
+			}
+		},
+		"unherit": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
+			}
+		},
+		"unified": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"requires": {
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^2.0.0",
+				"x-is-string": "^0.1.0"
+			}
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
+		},
+		"unist-builder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.3.tgz",
+			"integrity": "sha512-/KB8GEaoeHRyIqClL+Kam+Y5NWJ6yEiPsAfv1M+O1p+aKGgjR89WwoEHKTyOj17L6kAlqtKpAgv2nWvdbQDEig==",
+			"requires": {
+				"object-assign": "^4.1.0"
+			}
+		},
+		"unist-util-assert": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unist-util-assert/-/unist-util-assert-1.0.3.tgz",
+			"integrity": "sha512-0b1jHm8h5Hbz/prQAcg36uUUQeNaih09iwDBMxNrD2gejL7fs6W12jUJgwuHi+OC4fRztpPbNIbMnfspemmdGQ==",
+			"requires": {
+				"x-is-array": "^0.1.0",
+				"x-is-object": "^0.1.0"
+			}
+		},
+		"unist-util-is": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+		},
+		"unist-util-map": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-1.0.4.tgz",
+			"integrity": "sha512-Qv68pQz05hQbjPI+TubZQI5XII5DScRVWaKNc6+qfmHaFGxaGUbkV8i++mM2nk7XgwXE+vei99d/Q2d1tMA3EQ==",
+			"requires": {
+				"object-assign": "^4.0.1"
+			}
+		},
+		"unist-util-remove-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
+			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+			"requires": {
+				"unist-util-visit": "^1.1.0"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+		},
+		"unist-util-visit": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+			"integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+			"requires": {
+				"unist-util-visit-parents": "^2.0.0"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+			"integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+			"requires": {
+				"unist-util-is": "^2.1.2"
+			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"vfile": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"requires": {
+				"is-buffer": "^1.1.4",
+				"replace-ext": "1.0.0",
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			}
+		},
+		"vfile-location": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
+			"integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w=="
+		},
+		"vfile-message": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"requires": {
+				"unist-util-stringify-position": "^1.1.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
+			"requires": {
+				"makeerror": "1.0.x"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
+		},
+		"whatwg-encoding": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.24"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write-file-atomic": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"ws": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
+			}
+		},
+		"x-is-array": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz",
+			"integrity": "sha1-3lIBcdR7P0FvVYfWKbidJrEtwp0="
+		},
+		"x-is-object": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-object/-/x-is-object-0.1.0.tgz",
+			"integrity": "sha1-j5SW0Wht9IcVYJbnbKmUTvwVv+w="
+		},
+		"x-is-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^4.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
+			}
+		},
+		"yargs-parser": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
 			}
 		}
 	}

--- a/packages/curriculum-parser-json/package.json
+++ b/packages/curriculum-parser-json/package.json
@@ -4,6 +4,11 @@
   "description": "Parses Enki Curriculum JSON into an AST",
   "author": "Nemanja Stojanovic <nemanjacoder@gmail.com>",
   "main": "index.js",
+  "scripts": {
+    "test:watch": "jest --watchAll",
+    "test": "jest --coverage --notify",
+    "test:regex": "npm test -- regexToMatchFile"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/enkidevs/curriculum-processors.git"
@@ -32,10 +37,12 @@
   "dependencies": {
     "@enkidevs/curriculum-helpers": "^2.2.1",
     "@enkidevs/curriculum-parser-markdown": "^3.1.1",
-    "js-yaml": "^3.11.0",
-    "unist-builder": "^1.0.2"
+    "js-yaml": "^3.13.0",
+    "unist-builder": "^1.0.3"
   },
-  "jest": {
-    "testRegex": "/.*__tests__/.*\\.test.js$"
+  "devDependencies": {
+    "jest": "^24.5.0",
+    "jest-in-case": "^1.0.2",
+    "jsonfile": "^5.0.0"
   }
 }

--- a/packages/curriculum-parser-json/parsers/headline.js
+++ b/packages/curriculum-parser-json/parsers/headline.js
@@ -24,6 +24,10 @@ function createHeadlineNode(headlineAST) {
     headlineAST.children = headlineAST.children[0].children;
   }
 
+  if (headlineAST.type !== 'headline') {
+    delete headlineAST.type;
+  }
+
   return unistBuilder('headline', headlineAST);
 }
 

--- a/packages/curriculum-parser-markdown/README.md
+++ b/packages/curriculum-parser-markdown/README.md
@@ -234,7 +234,7 @@ interface AnswersList <: Parent {
   type: "list";
   ordered: false;
   start: null;
-  loose: true | false;
+  spread: true | false;
   answers: true;
 }
 ```
@@ -255,12 +255,12 @@ Yields:
   "type": "list",
   "ordered": false,
   "start": null,
-  "loose": false,
+  "spread": false,
   "answers": true,
   "children": [
     {
       "type": "listItem",
-      "loose": false,
+      "spread": false,
       "checked": null,
       "correct": true,
       "children": [
@@ -277,7 +277,7 @@ Yields:
     },
     {
       "type": "listItem",
-      "loose": false,
+      "spread": false,
       "checked": null,
       "correct": false,
       "children": [
@@ -294,7 +294,7 @@ Yields:
     },
     {
       "type": "listItem",
-      "loose": false,
+      "spread": false,
       "checked": null,
       "correct": false,
       "children": [
@@ -311,7 +311,7 @@ Yields:
     },
     {
       "type": "listItem",
-      "loose": false,
+      "spread": false,
       "checked": null,
       "correct": false,
       "children": [
@@ -341,7 +341,7 @@ It is a direct child of [`AnswersList`](#answerslist) and does not contain a che
 ```idl
 interface AnswersListItem <: Parent {
   type: "listItem";
-  loose: true | false;
+  spread: true | false;
   checked: null;
   correct: true | false;
 }

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/insight/sample/ast.json
@@ -3,22 +3,19 @@
   "children": [
     {
       "type": "yaml",
-      "value": "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n    - >-\n        [Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}\n\nparent: removing-keys-from-a-binary-search-tree",
+      "value":
+        "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n    - >-\n        [Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}\n\nparent: removing-keys-from-a-binary-search-tree",
       "data": {
         "parsedValue": {
           "author": "jfarmer",
-          "levels": [
-            "beginner",
-            "basic",
-            "medium",
-            "advanced"
-          ],
+          "levels": ["beginner", "basic", "medium", "advanced"],
           "type": "normal",
           "category": "must-know",
           "links": [
             {
               "name": "Why is it safer to keep the tree balanced?",
-              "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
+              "url":
+                "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
               "nature": "website"
             }
           ],
@@ -57,7 +54,8 @@
             },
             {
               "type": "text",
-              "value": " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application."
+              "value":
+                " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application."
             }
           ]
         },
@@ -66,7 +64,8 @@
           "children": [
             {
               "type": "text",
-              "value": "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree."
+              "value":
+                "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree."
             }
           ]
         },
@@ -75,7 +74,8 @@
           "children": [
             {
               "type": "text",
-              "value": "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:"
+              "value":
+                "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:"
             }
           ]
         },
@@ -85,7 +85,8 @@
             {
               "type": "image",
               "title": null,
-              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "url":
+                "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
               "alt": "unbalanced",
               "svg": true
             }
@@ -114,7 +115,8 @@
             {
               "type": "image",
               "title": null,
-              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "url":
+                "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
               "alt": "balanced",
               "svg": true
             }
@@ -125,7 +127,8 @@
           "children": [
             {
               "type": "text",
-              "value": "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching "
+              "value":
+                "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching "
             },
             {
               "type": "emphasis",
@@ -147,11 +150,13 @@
           "children": [
             {
               "type": "text",
-              "value": "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees"
+              "value":
+                "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees"
             },
             {
               "type": "linkReference",
               "identifier": "1",
+              "label": "1",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -167,6 +172,7 @@
             {
               "type": "linkReference",
               "identifier": "2",
+              "label": "2",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -222,11 +228,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -243,7 +249,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -260,7 +266,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -277,7 +283,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -313,6 +319,7 @@
         },
         {
           "type": "code",
+          "meta": null,
           "lang": "bash",
           "value": "#!/bin/bash\na=1\n{ a=2 }\necho $a"
         },
@@ -320,11 +327,11 @@
           "type": "list",
           "ordered": false,
           "start": null,
-          "loose": false,
+          "spread": false,
           "children": [
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -341,7 +348,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -358,7 +365,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -375,7 +382,7 @@
             },
             {
               "type": "listItem",
-              "loose": false,
+              "spread": false,
               "checked": null,
               "children": [
                 {
@@ -406,6 +413,7 @@
             {
               "type": "linkReference",
               "identifier": "1: avl tree",
+              "label": "1: AVL tree",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -416,7 +424,8 @@
             },
             {
               "type": "text",
-              "value": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one."
+              "value":
+                "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one."
             }
           ]
         },
@@ -426,6 +435,7 @@
             {
               "type": "linkReference",
               "identifier": "2: red-black tree",
+              "label": "2: Red-Black tree",
               "referenceType": "shortcut",
               "children": [
                 {
@@ -436,7 +446,8 @@
             },
             {
               "type": "text",
-              "value": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black."
+              "value":
+                "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black."
             }
           ]
         }

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/question/code-with-external-question-gap/ast.json
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/question/code-with-external-question-gap/ast.json
@@ -12,6 +12,7 @@
     },
     {
       "type": "code",
+      "meta": null,
       "lang": "css",
       "value": "#div.selected a{}"
     },
@@ -28,11 +29,11 @@
       "type": "list",
       "ordered": false,
       "start": null,
-      "loose": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -49,7 +50,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -66,7 +67,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -83,7 +84,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -100,7 +101,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -117,7 +118,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/question/code-with-multiple-horizontal-question-gaps/ast.json
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/question/code-with-multiple-horizontal-question-gaps/ast.json
@@ -29,6 +29,7 @@
     {
       "type": "questionCode",
       "lang": "bash",
+      "meta": null,
       "value": "$ ??? ??? ??? eth0",
       "children": [
         {
@@ -74,11 +75,11 @@
       "type": "list",
       "ordered": false,
       "start": null,
-      "loose": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -95,7 +96,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -112,7 +113,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -129,7 +130,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -146,7 +147,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/question/code-with-multiple-vertical-question-gaps/ast.json
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/question/code-with-multiple-vertical-question-gaps/ast.json
@@ -13,6 +13,7 @@
     {
       "type": "questionCode",
       "lang": "bash",
+      "meta": null,
       "value": "#-i =???\n#-r =???\n#-c =???\n#default =???",
       "children": [
         {
@@ -77,11 +78,11 @@
       "type": "list",
       "ordered": false,
       "start": null,
-      "loose": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -98,7 +99,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -115,7 +116,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -132,7 +133,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/question/quiz/ast.json
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/question/quiz/ast.json
@@ -23,11 +23,11 @@
       "type": "list",
       "ordered": false,
       "start": null,
-      "loose": false,
+      "spread": false,
       "children": [
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -44,7 +44,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -61,7 +61,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {
@@ -78,7 +78,7 @@
         },
         {
           "type": "listItem",
-          "loose": false,
+          "spread": false,
           "checked": null,
           "children": [
             {

--- a/packages/curriculum-parser-markdown/index.js
+++ b/packages/curriculum-parser-markdown/index.js
@@ -24,9 +24,8 @@ function getParser(type) {
   function parse(md) {
     return new Promise((resolve, reject) => {
       const processor = getProcessor(type);
-      processor.run(
-        processor.parse(md),
-        (err, ast) => (err ? reject(err) : resolve(ast))
+      processor.run(processor.parse(md), (err, ast) =>
+        err ? reject(err) : resolve(ast)
       );
     });
   }

--- a/packages/curriculum-parser-markdown/jest.config.js
+++ b/packages/curriculum-parser-markdown/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  testRegex: '.*/__tests__/.*\\.test.js$',
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/dist/**',
+    '!**/__tests__/**',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+    '!**/*sandbox.js',
+  ],
+};

--- a/packages/curriculum-parser-markdown/package-lock.json
+++ b/packages/curriculum-parser-markdown/package-lock.json
@@ -1,19 +1,914 @@
 {
-	"requires": true,
+	"name": "@enkidevs/curriculum-parser-markdown",
+	"version": "3.1.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/core": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+			"integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helpers": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"convert-source-map": "^1.1.0",
+				"debug": "^4.1.0",
+				"json5": "^2.1.0",
+				"lodash": "^4.17.11",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.11",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/helpers": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
+			"integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+			"dev": true,
+			"requires": {
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+			"integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+			"dev": true
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+			"integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.4.0",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.11"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"dev": true,
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
+			}
+		},
+		"@jest/console": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
+			"integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
+			"dev": true,
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"@types/node": "*",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.5.0.tgz",
+			"integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/reporters": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-changed-files": "^24.5.0",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve-dependencies": "^24.5.0",
+				"jest-runner": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"jest-watcher": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"p-each-series": "^1.0.0",
+				"pirates": "^4.0.1",
+				"realpath-native": "^1.1.0",
+				"rimraf": "^2.5.4",
+				"strip-ansi": "^5.0.0"
+			}
+		},
+		"@jest/environment": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.5.0.tgz",
+			"integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
+			"dev": true,
+			"requires": {
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.5.0.tgz",
+			"integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.5.0.tgz",
+			"integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"istanbul-api": "^2.1.1",
+				"istanbul-lib-coverage": "^2.0.2",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-source-maps": "^3.0.1",
+				"jest-haste-map": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"node-notifier": "^5.2.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.5.0.tgz",
+			"integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/types": "^24.5.0",
+				"@types/istanbul-lib-coverage": "^1.1.0"
+			}
+		},
+		"@jest/transform": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.5.0.tgz",
+			"integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"chalk": "^2.0.1",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"jest-haste-map": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "2.4.1"
+			}
+		},
+		"@jest/types": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
+			"integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^1.1.0",
+				"@types/yargs": "^12.0.9"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
+			"integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
+			"integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/unist": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
+		},
+		"@types/vfile": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*",
+				"@types/vfile-message": "*"
+			}
+		},
+		"@types/vfile-message": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+			"requires": {
+				"@types/node": "*",
+				"@types/unist": "*"
+			}
+		},
+		"@types/yargs": {
+			"version": "12.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
+			"dev": true
+		},
+		"abab": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"dev": true
+		},
+		"acorn-globals": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"dev": true,
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"dev": true
+				}
+			}
+		},
+		"acorn-walk": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"anymatch": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			}
+		},
+		"append-transform": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+			"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+			"dev": true,
+			"requires": {
+				"default-require-extensions": "^2.0.0"
+			}
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+			"dev": true
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+			"dev": true
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"dev": true
+		},
+		"babel-jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.5.0.tgz",
+			"integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
+			"dev": true,
+			"requires": {
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/babel__core": "^7.1.0",
+				"babel-plugin-istanbul": "^5.1.0",
+				"babel-preset-jest": "^24.3.0",
+				"chalk": "^2.4.2",
+				"slash": "^2.0.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
+			"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"istanbul-lib-instrument": "^3.0.0",
+				"test-exclude": "^5.0.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
+			"integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+			"dev": true,
+			"requires": {
+				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
+			"integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
+			"dev": true,
+			"requires": {
+				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+				"babel-plugin-jest-hoist": "^24.3.0"
 			}
 		},
 		"bail": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
 			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+			"integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+			"dev": true
+		},
+		"browser-resolve": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"dev": true,
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
+		"callsites": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+			"dev": true
+		},
+		"camelcase": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+			"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+			"dev": true
+		},
+		"capture-exit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+			"dev": true,
+			"requires": {
+				"rsvp": "^4.8.4"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
 		},
 		"character-entities": {
 			"version": "1.2.2",
@@ -30,32 +925,701 @@
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
 			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
 		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cliui": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
 		"collapse-white-space": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
 			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"dev": true,
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"combined-stream": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"dev": true,
+			"optional": true
+		},
+		"compare-versions": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
+			"integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"cssom": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"dev": true
+		},
+		"cssstyle": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+			"integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+			"dev": true,
+			"requires": {
+				"cssom": "0.3.x"
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"default-require-extensions": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+			"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+			"dev": true,
+			"requires": {
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"dev": true
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-keys": "^1.0.12"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"escodegen": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"dev": true,
+			"requires": {
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				}
+			}
+		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+		},
+		"estraverse": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"exec-sh": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+			"integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+			"dev": true
+		},
+		"execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"dev": true,
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"expect": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.5.0.tgz",
+			"integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-styles": "^3.2.0",
+				"jest-get-type": "^24.3.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-regex-util": "^24.3.0"
+			}
 		},
 		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"dev": true,
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
+		"fast-deep-equal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fault": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
 			"integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
 			"requires": {
-				"format": "0.2.2"
+				"format": "^0.2.2"
+			}
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
+			"requires": {
+				"bser": "^2.0.0"
+			}
+		},
+		"fileset": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
+			}
+		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^3.0.0"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
 			}
 		},
 		"format": {
@@ -63,10 +1627,270 @@
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
 			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+			"dev": true
+		},
+		"get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"globals": {
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+			"integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "^1.0.1"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"import-local": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^3.0.0",
+				"resolve-cwd": "^2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"invert-kv": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+			"dev": true
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"is-alphabetical": {
 			"version": "1.0.2",
@@ -78,47 +1902,995 @@
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
 			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
 			"requires": {
-				"is-alphabetical": "1.0.2",
-				"is-decimal": "1.0.2"
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
 			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-callable": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+			"dev": true
+		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-decimal": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
 			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
 		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-generator-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.0.0.tgz",
+			"integrity": "sha512-elzyIdM7iKoFHzcrndIqjYomImhxrFRnGP3galODoII4TB9gI7mZ+FnlLQmmjf27SxHS2gKEeyhX5/+YRS6H9g==",
+			"dev": true
+		},
 		"is-hexadecimal": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
 			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.1"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.0"
+			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
+		},
 		"is-whitespace-character": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
 			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"is-word-character": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
 			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA=="
 		},
-		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"dev": true
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"istanbul-api": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
+			"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"async": "^2.6.1",
+				"compare-versions": "^3.2.1",
+				"fileset": "^2.0.3",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.1.0",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.1",
+				"js-yaml": "^3.12.0",
+				"make-dir": "^1.3.0",
+				"minimatch": "^3.0.4",
+				"once": "^1.4.0"
+			}
+		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"dev": true
+		},
+		"istanbul-lib-hook": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+			"dev": true,
+			"requires": {
+				"append-transform": "^1.0.0"
+			}
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.3",
+				"semver": "^5.5.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+			"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+			"dev": true,
+			"requires": {
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"supports-color": "^6.0.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+			"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^2.0.3",
+				"make-dir": "^1.3.0",
+				"rimraf": "^2.6.2",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"istanbul-reports": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+			"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+			"dev": true,
+			"requires": {
+				"handlebars": "^4.1.0"
+			}
+		},
+		"jest": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.5.0.tgz",
+			"integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
+			"dev": true,
+			"requires": {
+				"import-local": "^2.0.0",
+				"jest-cli": "^24.5.0"
+			},
+			"dependencies": {
+				"jest-cli": {
+					"version": "24.5.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.5.0.tgz",
+					"integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
+					"dev": true,
+					"requires": {
+						"@jest/core": "^24.5.0",
+						"@jest/test-result": "^24.5.0",
+						"@jest/types": "^24.5.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"import-local": "^2.0.0",
+						"is-ci": "^2.0.0",
+						"jest-config": "^24.5.0",
+						"jest-util": "^24.5.0",
+						"jest-validate": "^24.5.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^1.1.0",
+						"yargs": "^12.0.2"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.5.0.tgz",
+			"integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"execa": "^1.0.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-config": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.5.0.tgz",
+			"integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^24.5.0",
+				"babel-jest": "^24.5.0",
+				"chalk": "^2.0.1",
+				"glob": "^7.1.1",
+				"jest-environment-jsdom": "^24.5.0",
+				"jest-environment-node": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"micromatch": "^3.1.10",
+				"pretty-format": "^24.5.0",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-diff": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.5.0.tgz",
+			"integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"dev": true,
+			"requires": {
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.5.0.tgz",
+			"integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.5.0.tgz",
+			"integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jsdom": "^11.5.1"
+			}
+		},
+		"jest-environment-node": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.5.0.tgz",
+			"integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
+			"dev": true,
+			"requires": {
+				"@jest/environment": "^24.5.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-util": "^24.5.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+			"integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
+			"dev": true
+		},
+		"jest-haste-map": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.5.0.tgz",
+			"integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"fb-watchman": "^2.0.0",
+				"graceful-fs": "^4.1.15",
+				"invariant": "^2.2.4",
+				"jest-serializer": "^24.4.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"micromatch": "^3.1.10",
+				"sane": "^4.0.3"
+			}
+		},
+		"jest-in-case": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/jest-in-case/-/jest-in-case-1.0.2.tgz",
+			"integrity": "sha1-VnRLWvMyIr0KurcM+Rnx0XCrdcw=",
+			"dev": true
+		},
+		"jest-jasmine2": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.5.0.tgz",
+			"integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"co": "^4.6.0",
+				"expect": "^24.5.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"pretty-format": "^24.5.0",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.5.0.tgz",
+			"integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.5.0.tgz",
+			"integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"jest-diff": "^24.5.0",
+				"jest-get-type": "^24.3.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.5.0.tgz",
+			"integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.5.0.tgz",
+			"integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+			"integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+			"dev": true
+		},
+		"jest-regex-util": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"dev": true
+		},
+		"jest-resolve": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.5.0.tgz",
+			"integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"browser-resolve": "^1.11.3",
+				"chalk": "^2.0.1",
+				"jest-pnp-resolver": "^1.2.1",
+				"realpath-native": "^1.1.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.5.0.tgz",
+			"integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-snapshot": "^24.5.0"
+			}
+		},
+		"jest-runner": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.5.0.tgz",
+			"integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.4.2",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-docblock": "^24.3.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-jasmine2": "^24.5.0",
+				"jest-leak-detector": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"jest-runtime": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-worker": "^24.4.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.5.0.tgz",
+			"integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/environment": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/transform": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/yargs": "^12.0.2",
+				"chalk": "^2.0.1",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"jest-config": "^24.5.0",
+				"jest-haste-map": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-mock": "^24.5.0",
+				"jest-regex-util": "^24.3.0",
+				"jest-resolve": "^24.5.0",
+				"jest-snapshot": "^24.5.0",
+				"jest-util": "^24.5.0",
+				"jest-validate": "^24.5.0",
+				"realpath-native": "^1.1.0",
+				"slash": "^2.0.0",
+				"strip-bom": "^3.0.0",
+				"yargs": "^12.0.2"
+			}
+		},
+		"jest-serializer": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"dev": true
+		},
+		"jest-snapshot": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.5.0.tgz",
+			"integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^24.5.0",
+				"chalk": "^2.0.1",
+				"expect": "^24.5.0",
+				"jest-diff": "^24.5.0",
+				"jest-matcher-utils": "^24.5.0",
+				"jest-message-util": "^24.5.0",
+				"jest-resolve": "^24.5.0",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^24.5.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"jest-util": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.5.0.tgz",
+			"integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.3.0",
+				"@jest/fake-timers": "^24.5.0",
+				"@jest/source-map": "^24.3.0",
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"callsites": "^3.0.0",
+				"chalk": "^2.0.1",
+				"graceful-fs": "^4.1.15",
+				"is-ci": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"slash": "^2.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"jest-validate": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
+			"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"camelcase": "^5.0.0",
+				"chalk": "^2.0.1",
+				"jest-get-type": "^24.3.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^24.5.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.5.0.tgz",
+			"integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
+			"dev": true,
+			"requires": {
+				"@jest/test-result": "^24.5.0",
+				"@jest/types": "^24.5.0",
+				"@types/node": "*",
+				"@types/yargs": "^12.0.9",
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"jest-util": "^24.5.0",
+				"string-length": "^2.0.0"
+			}
+		},
+		"jest-worker": {
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
+			"integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"merge-stream": "^1.0.1",
+				"supports-color": "^6.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+			"integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"jsdom": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+			"dev": true,
+			"requires": {
+				"abab": "^2.0.0",
+				"acorn": "^5.5.3",
+				"acorn-globals": "^4.1.0",
+				"array-equal": "^1.0.0",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": "^1.0.0",
+				"data-urls": "^1.0.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.9.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"left-pad": "^1.3.0",
+				"nwsapi": "^2.0.7",
+				"parse5": "4.0.0",
+				"pn": "^1.1.0",
+				"request": "^2.87.0",
+				"request-promise-native": "^1.0.5",
+				"sax": "^1.2.4",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^2.3.4",
+				"w3c-hr-time": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.3",
+				"whatwg-mimetype": "^2.1.0",
+				"whatwg-url": "^6.4.1",
+				"ws": "^5.2.0",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"json5": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
+		},
+		"jsonfile": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+			"integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^0.1.2"
+			}
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.2.tgz",
+			"integrity": "sha512-3h7B2WRT5LNXOtQiAaWonilegHcPSf9nLVXlSTci8lu1dZUuui61+EsPEZqSVxY7rXYmB2DVKMQILxaO5WL61Q==",
+			"dev": true
+		},
+		"lcid": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+			"dev": true,
+			"requires": {
+				"invert-kv": "^2.0.0"
+			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
+			"requires": {
+				"tmpl": "1.0.x"
+			}
+		},
+		"map-age-cleaner": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+			"dev": true,
+			"requires": {
+				"p-defer": "^1.0.0"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "^1.0.0"
 			}
 		},
 		"markdown-escapes": {
@@ -126,54 +2898,699 @@
 			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
 			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
 		},
+		"mem": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+			"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+			"dev": true,
+			"requires": {
+				"map-age-cleaner": "^0.1.1",
+				"mimic-fn": "^2.0.0",
+				"p-is-promise": "^2.0.0"
+			}
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
+		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			}
+		},
+		"mime-db": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"dev": true,
+			"requires": {
+				"mime-db": "~1.38.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+			"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
+		},
+		"node-notifier": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"dev": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "^2.0.0"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"nwsapi": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+			"integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
-		"parse-entities": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
-			"integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
 			"requires": {
-				"character-entities": "1.2.2",
-				"character-entities-legacy": "1.1.2",
-				"character-reference-invalid": "1.1.2",
-				"is-alphanumerical": "1.0.2",
-				"is-decimal": "1.0.2",
-				"is-hexadecimal": "1.0.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+			"integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				}
+			}
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+					"dev": true
+				}
+			}
+		},
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"dev": true,
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			}
+		},
+		"p-defer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+			"dev": true
+		},
+		"p-each-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"p-is-promise": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"dev": true,
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
+		},
+		"p-try": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+			"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+			"dev": true
+		},
+		"parse-entities": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
+			"integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
+			"requires": {
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
+			}
+		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
+		"parse5": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"dev": true
+		},
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"dev": true,
+			"requires": {
+				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0"
+			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"pretty-format": {
+			"version": "24.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
+			"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.5.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
+			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"prompts": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+			"integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+			"dev": true,
+			"requires": {
+				"kleur": "^3.0.2",
+				"sisteransi": "^1.0.0"
+			}
+		},
+		"psl": {
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"dev": true
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
+		},
+		"react-is": {
+			"version": "16.8.5",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+			"integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==",
+			"dev": true
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+			"dev": true,
+			"requires": {
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"realpath-native": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+			"dev": true,
+			"requires": {
+				"util.promisify": "^1.0.0"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"remark-frontmatter": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.2.0.tgz",
-			"integrity": "sha512-BqcYv/ly+I94TiOM/n7iyNVBknzvTIblnQJiAg+6W/s/jxjtBIz5D66Tcjc20elFwW4hIqQI7R2UV1nlYumY3A==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.1.tgz",
+			"integrity": "sha512-Zj/fDMYnSVgMCeKp8fXIhtMoZq4G6E1dnwfMoO8fVXrm/+oVSiN8YMREtwN2cctgK9EsnYSeS1ExX2hcX/fE1A==",
 			"requires": {
-				"fault": "1.0.2",
-				"xtend": "4.0.1"
+				"fault": "^1.0.1",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remark-parse": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+			"integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
 			"requires": {
-				"collapse-white-space": "1.0.4",
-				"is-alphabetical": "1.0.2",
-				"is-decimal": "1.0.2",
-				"is-whitespace-character": "1.0.2",
-				"is-word-character": "1.0.2",
-				"markdown-escapes": "1.0.2",
-				"parse-entities": "1.1.2",
-				"repeat-string": "1.6.1",
-				"state-toggle": "1.0.1",
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^1.1.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
 				"trim": "0.0.1",
-				"trim-trailing-lines": "1.1.1",
-				"unherit": "1.1.1",
-				"unist-util-remove-position": "1.1.2",
-				"vfile-location": "2.0.3",
-				"xtend": "4.0.1"
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^1.0.0",
+				"vfile-location": "^2.0.0",
+				"xtend": "^4.0.1"
 			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
@@ -185,20 +3602,702 @@
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
+		"request": {
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.2",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^3.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+			"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+			"dev": true
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"rsvp": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+			"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"sane": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+			"dev": true,
+			"requires": {
+				"@cnakazawa/watch": "^1.0.3",
+				"anymatch": "^2.0.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
+				"fb-watchman": "^2.0.0",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5"
+			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sisteransi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"dev": true
+		},
+		"slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.11",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+			"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
+		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+			"dev": true
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
 		},
 		"state-toggle": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
 			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
 		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
+		},
+		"string-length": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+			"dev": true,
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^4.1.0"
+			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"dev": true
+		},
+		"test-exclude": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"minimatch": "^3.0.4",
+				"read-pkg-up": "^4.0.0",
+				"require-main-filename": "^1.0.1"
+			}
+		},
+		"throat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+			"dev": true
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"trim": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
 			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"trim-trailing-lines": {
 			"version": "1.1.1",
@@ -206,38 +4305,110 @@
 			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
 		},
 		"trough": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.2.tgz",
-			"integrity": "sha512-FHkoUZvG6Egrv9XZAyYGKEyb1JMsFphgPjoczkZC2y6W93U1jswcVURB8MUvtsahEPEVACyxD47JAL63vF4JsQ=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw=="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"uglify-js": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
+			"integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.19.0",
+				"source-map": "~0.6.1"
+			}
 		},
 		"unherit": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
 			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
 			"requires": {
-				"inherits": "2.0.3",
-				"xtend": "4.0.1"
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
 			}
 		},
 		"unified": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
 			"requires": {
-				"bail": "1.0.3",
-				"extend": "3.0.1",
-				"is-plain-obj": "1.1.0",
-				"trough": "1.0.2",
-				"vfile": "2.3.0",
-				"x-is-string": "0.1.0"
+				"@types/unist": "^2.0.0",
+				"@types/vfile": "^3.0.0",
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^3.0.0",
+				"x-is-string": "^0.1.0"
+			}
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
 			}
 		},
 		"unist-builder": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
-			"integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.3.tgz",
+			"integrity": "sha512-/KB8GEaoeHRyIqClL+Kam+Y5NWJ6yEiPsAfv1M+O1p+aKGgjR89WwoEHKTyOj17L6kAlqtKpAgv2nWvdbQDEig==",
 			"requires": {
-				"object-assign": "4.1.1"
+				"object-assign": "^4.1.0"
 			}
 		},
 		"unist-util-is": {
@@ -250,7 +4421,7 @@
 			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-1.0.4.tgz",
 			"integrity": "sha512-Qv68pQz05hQbjPI+TubZQI5XII5DScRVWaKNc6+qfmHaFGxaGUbkV8i++mM2nk7XgwXE+vei99d/Q2d1tMA3EQ==",
 			"requires": {
-				"object-assign": "4.1.1"
+				"object-assign": "^4.0.1"
 			}
 		},
 		"unist-util-remove-position": {
@@ -258,7 +4429,7 @@
 			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
 			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
 			"requires": {
-				"unist-util-visit": "1.3.1"
+				"unist-util-visit": "^1.1.0"
 			}
 		},
 		"unist-util-stringify-position": {
@@ -267,35 +4438,304 @@
 			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
 		},
 		"unist-util-visit": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.1.tgz",
-			"integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+			"integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
 			"requires": {
-				"unist-util-is": "2.1.2"
+				"unist-util-visit-parents": "^2.0.0"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+			"integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+			"requires": {
+				"unist-util-is": "^2.1.2"
+			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+			"dev": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"dev": true
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vfile": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
 			"requires": {
-				"is-buffer": "1.1.6",
+				"is-buffer": "^2.0.0",
 				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "1.1.2",
-				"vfile-message": "1.0.1"
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+				}
 			}
 		},
 		"vfile-location": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.3.tgz",
-			"integrity": "sha512-zM5/l4lfw1CBoPx3Jimxoc5RNDAHHpk6AM6LM0pTIkm5SUSsx8ZekZ0PVdf0WEZ7kjlhSt7ZlqbRL6Cd6dBs6A=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
+			"integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w=="
 		},
 		"vfile-message": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.1.tgz",
-			"integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
 			"requires": {
-				"unist-util-stringify-position": "1.1.2"
+				"unist-util-stringify-position": "^1.1.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
+			"requires": {
+				"makeerror": "1.0.x"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+			"dev": true
+		},
+		"whatwg-encoding": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "0.4.24"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+			"dev": true
+		},
+		"whatwg-url": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"write-file-atomic": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"ws": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"x-is-string": {
@@ -303,10 +4743,52 @@
 			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
 			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
 		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^4.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^3.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1 || ^4.0.0",
+				"yargs-parser": "^11.1.1"
+			}
+		},
+		"yargs-parser": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+			"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
 		}
 	}
 }

--- a/packages/curriculum-parser-markdown/package.json
+++ b/packages/curriculum-parser-markdown/package.json
@@ -4,6 +4,11 @@
   "description": "Parses Enki Curriculum markdown into an AST",
   "author": "Nemanja Stojanovic <nemanjacoder@gmail.com>",
   "main": "index.js",
+  "scripts": {
+    "test:watch": "jest --watchAll",
+    "test": "jest --coverage --notify",
+    "test:regex": "npm test -- regexToMatchFile"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/enkidevs/curriculum-processors.git"
@@ -32,15 +37,17 @@
   "dependencies": {
     "@enkidevs/curriculum-helpers": "^2.2.1",
     "decode-uri-component": "^0.2.0",
-    "js-yaml": "^3.11.0",
-    "remark-frontmatter": "^1.2.0",
-    "remark-parse": "^5.0.0",
-    "unified": "^6.1.6",
-    "unist-builder": "^1.0.2",
+    "js-yaml": "^3.13.0",
+    "remark-frontmatter": "^1.3.1",
+    "remark-parse": "^6.0.3",
+    "unified": "^7.1.0",
+    "unist-builder": "^1.0.3",
     "unist-util-map": "^1.0.3",
-    "unist-util-visit": "^1.3.0"
+    "unist-util-visit": "^1.4.0"
   },
-  "jest": {
-    "testRegex": "/.*__tests__/.*\\.test.js$"
+  "devDependencies": {
+    "jest": "^24.5.0",
+    "jest-in-case": "^1.0.2",
+    "jsonfile": "^5.0.0"
   }
 }

--- a/packages/curriculum-parser-markdown/plugins/question/code.js
+++ b/packages/curriculum-parser-markdown/plugins/question/code.js
@@ -18,11 +18,10 @@ module.exports = function questionCode() {
             undefined,
             line
               .split(/(\?{3})/) // split using a group so we also capture ???
-              .map(
-                chunk =>
-                  chunk === '???'
-                    ? u('questionGap', undefined, '???')
-                    : u('questionCodeSegment', { lang: node.lang }, chunk)
+              .map(chunk =>
+                chunk === '???'
+                  ? u('questionGap', undefined, '???')
+                  : u('questionCodeSegment', { lang: node.lang }, chunk)
               )
               .filter(n => Boolean(n.value)) // eliminate empty string nodes
               .reduce((lineChildren, curr, i) => {


### PR DESCRIPTION
:sparkles::recycle::package: Update all deps and cleanup the consequences

### Package

- [x] add `files` to the `package.json` of each package to make sure we only ship what's needed

- [x] move `jest`, `jest-in-case` and `jsonfile` as dev deps of individual packages (instead of having them globally)

### AST format

- [x] replace `loose` field in MDAST list item with `spread` (see https://github.com/syntax-tree/mdast/commit/fa392c24b04a5d9e6a582e6bb5951662ba7a1813#diff-0730bb7c2e8f9ea2438b52e419dd86c9) and https://github.com/remarkjs/remark/pull/364

- [x] add `meta` field to Enki MDAST node of type `questionCode` (which extends `code`) (see https://github.com/syntax-tree/mdast/commit/5bf67888e6050377dd964021030c33edff098d9b#diff-0730bb7c2e8f9ea2438b52e419dd86c9 and https://github.com/syntax-tree/mdast/pull/22)

- [x] Add a `label` to reference nodes (see https://github.com/syntax-tree/mdast/commit/dbb1ede9fce9146c68f31ce4f9c86c2a267ad700#diff-0730bb7c2e8f9ea2438b52e419dd86c9)
