### PR TITLE
Parser fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
       "npm run check-branch",
       "npm run format",
       "npm run lint",
-      "npm run test",
       "git add"
     ]
   }

--- a/packages/curriculum-compiler-json/README.md
+++ b/packages/curriculum-compiler-json/README.md
@@ -314,9 +314,9 @@ The final schema of a compiled JSON looks like:
     ]
   },
   "quiz": {
-    "rawText": "### Quiz title\n\n\nSample quiz question\n\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
+    "rawText": "### Quiz title\n\n\nSample quiz question\n\n???\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
     "headline": "Quiz title",
-    "question": "Sample quiz question\n",
+    "question": "Sample quiz question\n\n???\n",
     "answers": [
       {
         "text": "correct",

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/ast.json
@@ -3,8 +3,7 @@
   "children": [
     {
       "type": "yaml",
-      "value":
-        "author: catalin\n\nlevels:\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\n\ntags:\n  - introduction\n  - workout\n\nstub: false\n\nlinks:\n  - '[EnkiCool](https://enki.com){website}'\n",
+      "value": "author: catalin\nlevels:\n  - basic\n  - medium\n  - advanced\ntype: normal\ncategory: must-know\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\ntags:\n  - introduction\n  - workout\nstub: false\nlinks:\n  - '[EnkiCool](https://enki.com){website}'",
       "position": {
         "start": {
           "line": 1,
@@ -12,37 +11,11 @@
           "offset": 0
         },
         "end": {
-          "line": 26,
+          "line": 18,
           "column": 4,
-          "offset": 257
+          "offset": 249
         },
-        "indent": [
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1,
-          1
-        ]
+        "indent": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
       },
       "data": {
         "parsedValue": {
@@ -74,14 +47,14 @@
           "value": "Sample title with ",
           "position": {
             "start": {
-              "line": 27,
+              "line": 20,
               "column": 3,
-              "offset": 260
+              "offset": 253
             },
             "end": {
-              "line": 27,
+              "line": 20,
               "column": 21,
-              "offset": 278
+              "offset": 271
             },
             "indent": []
           }
@@ -91,14 +64,14 @@
           "value": "code",
           "position": {
             "start": {
-              "line": 27,
+              "line": 20,
               "column": 21,
-              "offset": 278
+              "offset": 271
             },
             "end": {
-              "line": 27,
+              "line": 20,
               "column": 27,
-              "offset": 284
+              "offset": 277
             },
             "indent": []
           }
@@ -108,14 +81,14 @@
           "value": " within",
           "position": {
             "start": {
-              "line": 27,
+              "line": 20,
               "column": 27,
-              "offset": 284
+              "offset": 277
             },
             "end": {
-              "line": 27,
+              "line": 20,
               "column": 34,
-              "offset": 291
+              "offset": 284
             },
             "indent": []
           }
@@ -134,14 +107,14 @@
               "value": "This is a sample paragraph.",
               "position": {
                 "start": {
-                  "line": 32,
+                  "line": 26,
                   "column": 1,
-                  "offset": 309
+                  "offset": 303
                 },
                 "end": {
-                  "line": 32,
+                  "line": 26,
                   "column": 28,
-                  "offset": 336
+                  "offset": 330
                 },
                 "indent": []
               }
@@ -157,14 +130,14 @@
                   "value": "1",
                   "position": {
                     "start": {
-                      "line": 32,
+                      "line": 26,
                       "column": 29,
-                      "offset": 337
+                      "offset": 331
                     },
                     "end": {
-                      "line": 32,
+                      "line": 26,
                       "column": 30,
-                      "offset": 338
+                      "offset": 332
                     },
                     "indent": []
                   }
@@ -172,14 +145,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 32,
+                  "line": 26,
                   "column": 28,
-                  "offset": 336
+                  "offset": 330
                 },
                 "end": {
-                  "line": 32,
+                  "line": 26,
                   "column": 31,
-                  "offset": 339
+                  "offset": 333
                 },
                 "indent": []
               }
@@ -187,14 +160,14 @@
           ],
           "position": {
             "start": {
-              "line": 32,
+              "line": 26,
               "column": 1,
-              "offset": 309
+              "offset": 303
             },
             "end": {
-              "line": 32,
+              "line": 26,
               "column": 31,
-              "offset": 339
+              "offset": 333
             },
             "indent": []
           }
@@ -207,14 +180,14 @@
               "value": "This is a sample list",
               "position": {
                 "start": {
-                  "line": 34,
+                  "line": 28,
                   "column": 1,
-                  "offset": 341
+                  "offset": 335
                 },
                 "end": {
-                  "line": 34,
+                  "line": 28,
                   "column": 22,
-                  "offset": 362
+                  "offset": 356
                 },
                 "indent": []
               }
@@ -230,14 +203,14 @@
                   "value": "2",
                   "position": {
                     "start": {
-                      "line": 34,
+                      "line": 28,
                       "column": 23,
-                      "offset": 363
+                      "offset": 357
                     },
                     "end": {
-                      "line": 34,
+                      "line": 28,
                       "column": 24,
-                      "offset": 364
+                      "offset": 358
                     },
                     "indent": []
                   }
@@ -245,14 +218,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 34,
+                  "line": 28,
                   "column": 22,
-                  "offset": 362
+                  "offset": 356
                 },
                 "end": {
-                  "line": 34,
+                  "line": 28,
                   "column": 25,
-                  "offset": 365
+                  "offset": 359
                 },
                 "indent": []
               }
@@ -262,14 +235,14 @@
               "value": ":",
               "position": {
                 "start": {
-                  "line": 34,
+                  "line": 28,
                   "column": 25,
-                  "offset": 365
+                  "offset": 359
                 },
                 "end": {
-                  "line": 34,
+                  "line": 28,
                   "column": 26,
-                  "offset": 366
+                  "offset": 360
                 },
                 "indent": []
               }
@@ -277,14 +250,14 @@
           ],
           "position": {
             "start": {
-              "line": 34,
+              "line": 28,
               "column": 1,
-              "offset": 341
+              "offset": 335
             },
             "end": {
-              "line": 34,
+              "line": 28,
               "column": 26,
-              "offset": 366
+              "offset": 360
             },
             "indent": []
           }
@@ -308,14 +281,14 @@
                       "value": "item one",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 30,
                           "column": 3,
-                          "offset": 370
+                          "offset": 364
                         },
                         "end": {
-                          "line": 36,
+                          "line": 30,
                           "column": 11,
-                          "offset": 378
+                          "offset": 372
                         },
                         "indent": []
                       }
@@ -323,14 +296,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 30,
                       "column": 3,
-                      "offset": 370
+                      "offset": 364
                     },
                     "end": {
-                      "line": 36,
+                      "line": 30,
                       "column": 11,
-                      "offset": 378
+                      "offset": 372
                     },
                     "indent": []
                   }
@@ -338,14 +311,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 30,
                   "column": 1,
-                  "offset": 368
+                  "offset": 362
                 },
                 "end": {
-                  "line": 36,
+                  "line": 30,
                   "column": 11,
-                  "offset": 378
+                  "offset": 372
                 },
                 "indent": []
               }
@@ -363,14 +336,14 @@
                       "value": "item ",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 31,
                           "column": 3,
-                          "offset": 381
+                          "offset": 375
                         },
                         "end": {
-                          "line": 37,
+                          "line": 31,
                           "column": 8,
-                          "offset": 386
+                          "offset": 380
                         },
                         "indent": []
                       }
@@ -380,14 +353,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 31,
                           "column": 8,
-                          "offset": 386
+                          "offset": 380
                         },
                         "end": {
-                          "line": 37,
+                          "line": 31,
                           "column": 13,
-                          "offset": 391
+                          "offset": 385
                         },
                         "indent": []
                       }
@@ -395,14 +368,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 31,
                       "column": 3,
-                      "offset": 381
+                      "offset": 375
                     },
                     "end": {
-                      "line": 37,
+                      "line": 31,
                       "column": 13,
-                      "offset": 391
+                      "offset": 385
                     },
                     "indent": []
                   }
@@ -410,14 +383,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 31,
                   "column": 1,
-                  "offset": 379
+                  "offset": 373
                 },
                 "end": {
-                  "line": 37,
+                  "line": 31,
                   "column": 13,
-                  "offset": 391
+                  "offset": 385
                 },
                 "indent": []
               }
@@ -425,14 +398,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 30,
               "column": 1,
-              "offset": 368
+              "offset": 362
             },
             "end": {
-              "line": 37,
+              "line": 31,
               "column": 13,
-              "offset": 391
+              "offset": 385
             },
             "indent": [1]
           }
@@ -445,14 +418,14 @@
               "value": "Sample code",
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 33,
                   "column": 1,
-                  "offset": 393
+                  "offset": 387
                 },
                 "end": {
-                  "line": 39,
+                  "line": 33,
                   "column": 12,
-                  "offset": 404
+                  "offset": 398
                 },
                 "indent": []
               }
@@ -468,14 +441,14 @@
                   "value": "3",
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 33,
                       "column": 13,
-                      "offset": 405
+                      "offset": 399
                     },
                     "end": {
-                      "line": 39,
+                      "line": 33,
                       "column": 14,
-                      "offset": 406
+                      "offset": 400
                     },
                     "indent": []
                   }
@@ -483,14 +456,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 33,
                   "column": 12,
-                  "offset": 404
+                  "offset": 398
                 },
                 "end": {
-                  "line": 39,
+                  "line": 33,
                   "column": 15,
-                  "offset": 407
+                  "offset": 401
                 },
                 "indent": []
               }
@@ -500,14 +473,14 @@
               "value": ":",
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 33,
                   "column": 15,
-                  "offset": 407
+                  "offset": 401
                 },
                 "end": {
-                  "line": 39,
+                  "line": 33,
                   "column": 16,
-                  "offset": 408
+                  "offset": 402
                 },
                 "indent": []
               }
@@ -515,33 +488,33 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 33,
               "column": 1,
-              "offset": 393
+              "offset": 387
             },
             "end": {
-              "line": 39,
+              "line": 33,
               "column": 16,
-              "offset": 408
+              "offset": 402
             },
             "indent": []
           }
         },
         {
           "type": "code",
-          "meta": null,
           "lang": "javascript",
+          "meta": null,
           "value": "console.log('sample code')",
           "position": {
             "start": {
-              "line": 40,
+              "line": 35,
               "column": 1,
-              "offset": 409
+              "offset": 404
             },
             "end": {
-              "line": 42,
+              "line": 37,
               "column": 4,
-              "offset": 453
+              "offset": 448
             },
             "indent": [1, 1]
           }
@@ -560,14 +533,14 @@
               "value": "This is a sample question with one gap:",
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 44,
                   "column": 1,
-                  "offset": 472
+                  "offset": 469
                 },
                 "end": {
-                  "line": 47,
+                  "line": 44,
                   "column": 40,
-                  "offset": 511
+                  "offset": 508
                 },
                 "indent": []
               }
@@ -575,14 +548,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 44,
               "column": 1,
-              "offset": 472
+              "offset": 469
             },
             "end": {
-              "line": 47,
+              "line": 44,
               "column": 40,
-              "offset": 511
+              "offset": 508
             },
             "indent": []
           }
@@ -595,14 +568,14 @@
               "value": "???",
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 46,
                   "column": 1,
-                  "offset": 513
+                  "offset": 510
                 },
                 "end": {
-                  "line": 49,
+                  "line": 46,
                   "column": 4,
-                  "offset": 516
+                  "offset": 513
                 },
                 "indent": []
               }
@@ -610,14 +583,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 46,
               "column": 1,
-              "offset": 513
+              "offset": 510
             },
             "end": {
-              "line": 49,
+              "line": 46,
               "column": 4,
-              "offset": 516
+              "offset": 513
             },
             "indent": []
           }
@@ -641,14 +614,14 @@
                       "value": "correct",
                       "position": {
                         "start": {
-                          "line": 51,
+                          "line": 48,
                           "column": 3,
-                          "offset": 520
+                          "offset": 517
                         },
                         "end": {
-                          "line": 51,
+                          "line": 48,
                           "column": 10,
-                          "offset": 527
+                          "offset": 524
                         },
                         "indent": []
                       }
@@ -656,14 +629,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 51,
+                      "line": 48,
                       "column": 3,
-                      "offset": 520
+                      "offset": 517
                     },
                     "end": {
-                      "line": 51,
+                      "line": 48,
                       "column": 10,
-                      "offset": 527
+                      "offset": 524
                     },
                     "indent": []
                   }
@@ -671,14 +644,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 51,
+                  "line": 48,
                   "column": 1,
-                  "offset": 518
+                  "offset": 515
                 },
                 "end": {
-                  "line": 51,
+                  "line": 48,
                   "column": 10,
-                  "offset": 527
+                  "offset": 524
                 },
                 "indent": []
               },
@@ -697,14 +670,14 @@
                       "value": "incorrect",
                       "position": {
                         "start": {
-                          "line": 52,
+                          "line": 49,
                           "column": 3,
-                          "offset": 530
+                          "offset": 527
                         },
                         "end": {
-                          "line": 52,
+                          "line": 49,
                           "column": 12,
-                          "offset": 539
+                          "offset": 536
                         },
                         "indent": []
                       }
@@ -712,14 +685,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 52,
+                      "line": 49,
                       "column": 3,
-                      "offset": 530
+                      "offset": 527
                     },
                     "end": {
-                      "line": 52,
+                      "line": 49,
                       "column": 12,
-                      "offset": 539
+                      "offset": 536
                     },
                     "indent": []
                   }
@@ -727,14 +700,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 52,
+                  "line": 49,
                   "column": 1,
-                  "offset": 528
+                  "offset": 525
                 },
                 "end": {
-                  "line": 52,
+                  "line": 49,
                   "column": 12,
-                  "offset": 539
+                  "offset": 536
                 },
                 "indent": []
               },
@@ -753,14 +726,14 @@
                       "value": "not a chance",
                       "position": {
                         "start": {
-                          "line": 53,
+                          "line": 50,
                           "column": 3,
-                          "offset": 542
+                          "offset": 539
                         },
                         "end": {
-                          "line": 53,
+                          "line": 50,
                           "column": 15,
-                          "offset": 554
+                          "offset": 551
                         },
                         "indent": []
                       }
@@ -768,14 +741,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 53,
+                      "line": 50,
                       "column": 3,
-                      "offset": 542
+                      "offset": 539
                     },
                     "end": {
-                      "line": 53,
+                      "line": 50,
                       "column": 15,
-                      "offset": 554
+                      "offset": 551
                     },
                     "indent": []
                   }
@@ -783,14 +756,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 53,
+                  "line": 50,
                   "column": 1,
-                  "offset": 540
+                  "offset": 537
                 },
                 "end": {
-                  "line": 53,
+                  "line": 50,
                   "column": 15,
-                  "offset": 554
+                  "offset": 551
                 },
                 "indent": []
               },
@@ -799,14 +772,14 @@
           ],
           "position": {
             "start": {
-              "line": 51,
+              "line": 48,
               "column": 1,
-              "offset": 518
+              "offset": 515
             },
             "end": {
-              "line": 53,
+              "line": 50,
               "column": 15,
-              "offset": 554
+              "offset": 551
             },
             "indent": [1, 1]
           },
@@ -827,15 +800,50 @@
               "value": "This is a sample question with two gaps:",
               "position": {
                 "start": {
-                  "line": 58,
+                  "line": 56,
                   "column": 1,
-                  "offset": 573
+                  "offset": 571
                 },
                 "end": {
-                  "line": 58,
+                  "line": 56,
                   "column": 41,
+                  "offset": 611
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 56,
+              "column": 1,
+              "offset": 571
+            },
+            "end": {
+              "line": 56,
+              "column": 41,
+              "offset": 611
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "questionGap",
+              "value": "???",
+              "position": {
+                "start": {
+                  "line": 58,
+                  "column": 1,
                   "offset": 613
                 },
+                "end": {
+                  "line": 58,
+                  "column": 4,
+                  "offset": 616
+                },
                 "indent": []
               }
             }
@@ -844,13 +852,13 @@
             "start": {
               "line": 58,
               "column": 1,
-              "offset": 573
-            },
-            "end": {
-              "line": 58,
-              "column": 41,
               "offset": 613
             },
+            "end": {
+              "line": 58,
+              "column": 4,
+              "offset": 616
+            },
             "indent": []
           }
         },
@@ -864,13 +872,13 @@
                 "start": {
                   "line": 60,
                   "column": 1,
-                  "offset": 615
-                },
-                "end": {
-                  "line": 60,
-                  "column": 4,
                   "offset": 618
                 },
+                "end": {
+                  "line": 60,
+                  "column": 4,
+                  "offset": 621
+                },
                 "indent": []
               }
             }
@@ -879,47 +887,12 @@
             "start": {
               "line": 60,
               "column": 1,
-              "offset": 615
-            },
-            "end": {
-              "line": 60,
-              "column": 4,
               "offset": 618
             },
-            "indent": []
-          }
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "questionGap",
-              "value": "???",
-              "position": {
-                "start": {
-                  "line": 62,
-                  "column": 1,
-                  "offset": 620
-                },
-                "end": {
-                  "line": 62,
-                  "column": 4,
-                  "offset": 623
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 62,
-              "column": 1,
-              "offset": 620
-            },
             "end": {
-              "line": 62,
+              "line": 60,
               "column": 4,
-              "offset": 623
+              "offset": 621
             },
             "indent": []
           }
@@ -943,14 +916,14 @@
                       "value": "correct",
                       "position": {
                         "start": {
-                          "line": 64,
+                          "line": 62,
                           "column": 3,
-                          "offset": 627
+                          "offset": 625
                         },
                         "end": {
-                          "line": 64,
+                          "line": 62,
                           "column": 10,
-                          "offset": 634
+                          "offset": 632
                         },
                         "indent": []
                       }
@@ -958,14 +931,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 64,
+                      "line": 62,
                       "column": 3,
-                      "offset": 627
+                      "offset": 625
                     },
                     "end": {
-                      "line": 64,
+                      "line": 62,
                       "column": 10,
-                      "offset": 634
+                      "offset": 632
                     },
                     "indent": []
                   }
@@ -973,14 +946,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 64,
+                  "line": 62,
                   "column": 1,
-                  "offset": 625
+                  "offset": 623
                 },
                 "end": {
-                  "line": 64,
+                  "line": 62,
                   "column": 10,
-                  "offset": 634
+                  "offset": 632
                 },
                 "indent": []
               },
@@ -999,14 +972,14 @@
                       "value": "also correct",
                       "position": {
                         "start": {
-                          "line": 65,
+                          "line": 63,
                           "column": 3,
-                          "offset": 637
+                          "offset": 635
                         },
                         "end": {
-                          "line": 65,
+                          "line": 63,
                           "column": 15,
-                          "offset": 649
+                          "offset": 647
                         },
                         "indent": []
                       }
@@ -1014,14 +987,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 65,
+                      "line": 63,
                       "column": 3,
-                      "offset": 637
+                      "offset": 635
                     },
                     "end": {
-                      "line": 65,
+                      "line": 63,
                       "column": 15,
-                      "offset": 649
+                      "offset": 647
                     },
                     "indent": []
                   }
@@ -1029,14 +1002,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 65,
+                  "line": 63,
                   "column": 1,
-                  "offset": 635
+                  "offset": 633
                 },
                 "end": {
-                  "line": 65,
+                  "line": 63,
                   "column": 15,
-                  "offset": 649
+                  "offset": 647
                 },
                 "indent": []
               },
@@ -1055,14 +1028,14 @@
                       "value": "nah bro",
                       "position": {
                         "start": {
-                          "line": 66,
+                          "line": 64,
                           "column": 3,
-                          "offset": 652
+                          "offset": 650
                         },
                         "end": {
-                          "line": 66,
+                          "line": 64,
                           "column": 10,
-                          "offset": 659
+                          "offset": 657
                         },
                         "indent": []
                       }
@@ -1070,14 +1043,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 66,
+                      "line": 64,
                       "column": 3,
-                      "offset": 652
+                      "offset": 650
                     },
                     "end": {
-                      "line": 66,
+                      "line": 64,
                       "column": 10,
-                      "offset": 659
+                      "offset": 657
                     },
                     "indent": []
                   }
@@ -1085,14 +1058,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 66,
+                  "line": 64,
                   "column": 1,
-                  "offset": 650
+                  "offset": 648
                 },
                 "end": {
-                  "line": 66,
+                  "line": 64,
                   "column": 10,
-                  "offset": 659
+                  "offset": 657
                 },
                 "indent": []
               },
@@ -1111,14 +1084,14 @@
                       "value": "fam, just no",
                       "position": {
                         "start": {
-                          "line": 67,
+                          "line": 65,
                           "column": 3,
-                          "offset": 662
+                          "offset": 660
                         },
                         "end": {
-                          "line": 67,
+                          "line": 65,
                           "column": 15,
-                          "offset": 674
+                          "offset": 672
                         },
                         "indent": []
                       }
@@ -1126,14 +1099,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 67,
+                      "line": 65,
                       "column": 3,
-                      "offset": 662
+                      "offset": 660
                     },
                     "end": {
-                      "line": 67,
+                      "line": 65,
                       "column": 15,
-                      "offset": 674
+                      "offset": 672
                     },
                     "indent": []
                   }
@@ -1141,14 +1114,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 67,
+                  "line": 65,
                   "column": 1,
-                  "offset": 660
+                  "offset": 658
                 },
                 "end": {
-                  "line": 67,
+                  "line": 65,
                   "column": 15,
-                  "offset": 674
+                  "offset": 672
                 },
                 "indent": []
               },
@@ -1157,14 +1130,14 @@
           ],
           "position": {
             "start": {
-              "line": 64,
+              "line": 62,
               "column": 1,
-              "offset": 625
+              "offset": 623
             },
             "end": {
-              "line": 67,
+              "line": 65,
               "column": 15,
-              "offset": 674
+              "offset": 672
             },
             "indent": [1, 1, 1]
           },
@@ -1207,14 +1180,14 @@
               "value": "Sample quiz question",
               "position": {
                 "start": {
-                  "line": 74,
+                  "line": 75,
                   "column": 1,
-                  "offset": 705
+                  "offset": 706
                 },
                 "end": {
-                  "line": 74,
+                  "line": 75,
                   "column": 21,
-                  "offset": 725
+                  "offset": 726
                 },
                 "indent": []
               }
@@ -1222,14 +1195,49 @@
           ],
           "position": {
             "start": {
-              "line": 74,
+              "line": 75,
               "column": 1,
-              "offset": 705
+              "offset": 706
             },
             "end": {
-              "line": 74,
+              "line": 75,
               "column": 21,
-              "offset": 725
+              "offset": 726
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "questionGap",
+              "value": "???",
+              "position": {
+                "start": {
+                  "line": 77,
+                  "column": 1,
+                  "offset": 728
+                },
+                "end": {
+                  "line": 77,
+                  "column": 4,
+                  "offset": 731
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 77,
+              "column": 1,
+              "offset": 728
+            },
+            "end": {
+              "line": 77,
+              "column": 4,
+              "offset": 731
             },
             "indent": []
           }
@@ -1253,14 +1261,14 @@
                       "value": "correct",
                       "position": {
                         "start": {
-                          "line": 76,
+                          "line": 79,
                           "column": 3,
-                          "offset": 729
+                          "offset": 735
                         },
                         "end": {
-                          "line": 76,
+                          "line": 79,
                           "column": 10,
-                          "offset": 736
+                          "offset": 742
                         },
                         "indent": []
                       }
@@ -1268,14 +1276,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 76,
+                      "line": 79,
                       "column": 3,
-                      "offset": 729
+                      "offset": 735
                     },
                     "end": {
-                      "line": 76,
+                      "line": 79,
                       "column": 10,
-                      "offset": 736
+                      "offset": 742
                     },
                     "indent": []
                   }
@@ -1283,14 +1291,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 76,
+                  "line": 79,
                   "column": 1,
-                  "offset": 727
+                  "offset": 733
                 },
                 "end": {
-                  "line": 76,
+                  "line": 79,
                   "column": 10,
-                  "offset": 736
+                  "offset": 742
                 },
                 "indent": []
               },
@@ -1312,14 +1320,14 @@
                           "value": "incorrect",
                           "position": {
                             "start": {
-                              "line": 77,
+                              "line": 80,
                               "column": 4,
-                              "offset": 740
+                              "offset": 746
                             },
                             "end": {
-                              "line": 77,
+                              "line": 80,
                               "column": 13,
-                              "offset": 749
+                              "offset": 755
                             },
                             "indent": []
                           }
@@ -1327,14 +1335,14 @@
                       ],
                       "position": {
                         "start": {
-                          "line": 77,
+                          "line": 80,
                           "column": 3,
-                          "offset": 739
+                          "offset": 745
                         },
                         "end": {
-                          "line": 77,
+                          "line": 80,
                           "column": 14,
-                          "offset": 750
+                          "offset": 756
                         },
                         "indent": []
                       }
@@ -1342,14 +1350,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 80,
                       "column": 3,
-                      "offset": 739
+                      "offset": 745
                     },
                     "end": {
-                      "line": 77,
+                      "line": 80,
                       "column": 14,
-                      "offset": 750
+                      "offset": 756
                     },
                     "indent": []
                   }
@@ -1357,14 +1365,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 80,
                   "column": 1,
-                  "offset": 737
+                  "offset": 743
                 },
                 "end": {
-                  "line": 77,
+                  "line": 80,
                   "column": 14,
-                  "offset": 750
+                  "offset": 756
                 },
                 "indent": []
               },
@@ -1383,14 +1391,14 @@
                       "value": "not a ",
                       "position": {
                         "start": {
-                          "line": 78,
+                          "line": 81,
                           "column": 3,
-                          "offset": 753
+                          "offset": 759
                         },
                         "end": {
-                          "line": 78,
+                          "line": 81,
                           "column": 9,
-                          "offset": 759
+                          "offset": 765
                         },
                         "indent": []
                       }
@@ -1400,14 +1408,14 @@
                       "value": "chance",
                       "position": {
                         "start": {
-                          "line": 78,
+                          "line": 81,
                           "column": 9,
-                          "offset": 759
+                          "offset": 765
                         },
                         "end": {
-                          "line": 78,
+                          "line": 81,
                           "column": 17,
-                          "offset": 767
+                          "offset": 773
                         },
                         "indent": []
                       }
@@ -1415,14 +1423,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 81,
                       "column": 3,
-                      "offset": 753
+                      "offset": 759
                     },
                     "end": {
-                      "line": 78,
+                      "line": 81,
                       "column": 17,
-                      "offset": 767
+                      "offset": 773
                     },
                     "indent": []
                   }
@@ -1430,14 +1438,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 78,
+                  "line": 81,
                   "column": 1,
-                  "offset": 751
+                  "offset": 757
                 },
                 "end": {
-                  "line": 78,
+                  "line": 81,
                   "column": 17,
-                  "offset": 767
+                  "offset": 773
                 },
                 "indent": []
               },
@@ -1456,14 +1464,14 @@
                       "value": "nope",
                       "position": {
                         "start": {
-                          "line": 79,
+                          "line": 82,
                           "column": 3,
-                          "offset": 770
+                          "offset": 776
                         },
                         "end": {
-                          "line": 79,
+                          "line": 82,
                           "column": 7,
-                          "offset": 774
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1471,14 +1479,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 82,
                       "column": 3,
-                      "offset": 770
+                      "offset": 776
                     },
                     "end": {
-                      "line": 79,
+                      "line": 82,
                       "column": 7,
-                      "offset": 774
+                      "offset": 780
                     },
                     "indent": []
                   }
@@ -1486,14 +1494,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 79,
+                  "line": 82,
                   "column": 1,
-                  "offset": 768
+                  "offset": 774
                 },
                 "end": {
-                  "line": 79,
+                  "line": 82,
                   "column": 7,
-                  "offset": 774
+                  "offset": 780
                 },
                 "indent": []
               },
@@ -1502,14 +1510,14 @@
           ],
           "position": {
             "start": {
-              "line": 76,
+              "line": 79,
               "column": 1,
-              "offset": 727
+              "offset": 733
             },
             "end": {
-              "line": 79,
+              "line": 82,
               "column": 7,
-              "offset": 774
+              "offset": 780
             },
             "indent": [1, 1, 1]
           },
@@ -1536,14 +1544,14 @@
                   "value": "1: Paragraph",
                   "position": {
                     "start": {
-                      "line": 84,
+                      "line": 89,
                       "column": 2,
-                      "offset": 795
+                      "offset": 803
                     },
                     "end": {
-                      "line": 84,
+                      "line": 89,
                       "column": 14,
-                      "offset": 807
+                      "offset": 815
                     },
                     "indent": []
                   }
@@ -1551,14 +1559,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 84,
+                  "line": 89,
                   "column": 1,
-                  "offset": 794
+                  "offset": 802
                 },
                 "end": {
-                  "line": 84,
+                  "line": 89,
                   "column": 15,
-                  "offset": 808
+                  "offset": 816
                 },
                 "indent": []
               }
@@ -1568,14 +1576,14 @@
               "value": "\nSample explanation",
               "position": {
                 "start": {
-                  "line": 84,
+                  "line": 89,
                   "column": 15,
-                  "offset": 808
+                  "offset": 816
                 },
                 "end": {
-                  "line": 85,
+                  "line": 90,
                   "column": 19,
-                  "offset": 827
+                  "offset": 835
                 },
                 "indent": [1]
               }
@@ -1583,14 +1591,14 @@
           ],
           "position": {
             "start": {
-              "line": 84,
+              "line": 89,
               "column": 1,
-              "offset": 794
+              "offset": 802
             },
             "end": {
-              "line": 85,
+              "line": 90,
               "column": 19,
-              "offset": 827
+              "offset": 835
             },
             "indent": [1]
           }
@@ -1609,14 +1617,14 @@
                   "value": "2: List",
                   "position": {
                     "start": {
-                      "line": 87,
+                      "line": 92,
                       "column": 2,
-                      "offset": 830
+                      "offset": 838
                     },
                     "end": {
-                      "line": 87,
+                      "line": 92,
                       "column": 9,
-                      "offset": 837
+                      "offset": 845
                     },
                     "indent": []
                   }
@@ -1624,14 +1632,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 87,
+                  "line": 92,
                   "column": 1,
-                  "offset": 829
+                  "offset": 837
                 },
                 "end": {
-                  "line": 87,
+                  "line": 92,
                   "column": 10,
-                  "offset": 838
+                  "offset": 846
                 },
                 "indent": []
               }
@@ -1641,14 +1649,14 @@
               "value": "\nSample list",
               "position": {
                 "start": {
-                  "line": 87,
+                  "line": 92,
                   "column": 10,
-                  "offset": 838
+                  "offset": 846
                 },
                 "end": {
-                  "line": 88,
+                  "line": 93,
                   "column": 12,
-                  "offset": 850
+                  "offset": 858
                 },
                 "indent": [1]
               }
@@ -1656,14 +1664,14 @@
           ],
           "position": {
             "start": {
-              "line": 87,
+              "line": 92,
               "column": 1,
-              "offset": 829
+              "offset": 837
             },
             "end": {
-              "line": 88,
+              "line": 93,
               "column": 12,
-              "offset": 850
+              "offset": 858
             },
             "indent": [1]
           }
@@ -1682,14 +1690,14 @@
                   "value": "3: Code",
                   "position": {
                     "start": {
-                      "line": 90,
+                      "line": 95,
                       "column": 2,
-                      "offset": 853
+                      "offset": 861
                     },
                     "end": {
-                      "line": 90,
+                      "line": 95,
                       "column": 9,
-                      "offset": 860
+                      "offset": 868
                     },
                     "indent": []
                   }
@@ -1697,14 +1705,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 90,
+                  "line": 95,
                   "column": 1,
-                  "offset": 852
+                  "offset": 860
                 },
                 "end": {
-                  "line": 90,
+                  "line": 95,
                   "column": 10,
-                  "offset": 861
+                  "offset": 869
                 },
                 "indent": []
               }
@@ -1714,14 +1722,14 @@
               "value": "\nSample code",
               "position": {
                 "start": {
-                  "line": 90,
+                  "line": 95,
                   "column": 10,
-                  "offset": 861
+                  "offset": 869
                 },
                 "end": {
-                  "line": 91,
+                  "line": 96,
                   "column": 12,
-                  "offset": 873
+                  "offset": 881
                 },
                 "indent": [1]
               }
@@ -1729,33 +1737,33 @@
           ],
           "position": {
             "start": {
-              "line": 90,
+              "line": 95,
               "column": 1,
-              "offset": 852
+              "offset": 860
             },
             "end": {
-              "line": 91,
+              "line": 96,
               "column": 12,
-              "offset": 873
+              "offset": 881
             },
             "indent": [1]
           }
         },
         {
           "type": "code",
-          "meta": null,
           "lang": "javascript",
+          "meta": null,
           "value": "var x = 10",
           "position": {
             "start": {
-              "line": 92,
+              "line": 98,
               "column": 1,
-              "offset": 874
+              "offset": 883
             },
             "end": {
-              "line": 94,
+              "line": 100,
               "column": 4,
-              "offset": 902
+              "offset": 911
             },
             "indent": [1, 1]
           }
@@ -1770,9 +1778,9 @@
       "offset": 0
     },
     "end": {
-      "line": 95,
+      "line": 101,
       "column": 1,
-      "offset": 903
+      "offset": 912
     }
   }
 }

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
@@ -1,21 +1,14 @@
 {
   "metadata": {
     "author": "catalin",
-    "levels": [
-      "basic",
-      "medium",
-      "advanced"
-    ],
+    "levels": ["basic", "medium", "advanced"],
     "type": "normal",
     "category": "must-know",
     "standards": {
       "sql.use-dql.0": 10,
       "sql.use-ddl.1": 1000
     },
-    "tags": [
-      "introduction",
-      "workout"
-    ],
+    "tags": ["introduction", "workout"],
     "stub": false,
     "links": [
       {
@@ -75,9 +68,9 @@
     ]
   },
   "quiz": {
-    "rawText": "### Quiz title\n\n\nSample quiz question\n\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
+    "rawText": "### Quiz title\n\n\nSample quiz question\n\n???\n\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
     "headline": "Quiz title",
-    "question": "Sample quiz question\n",
+    "question": "Sample quiz question\n\n???\n",
     "answers": [
       {
         "text": "correct",

--- a/packages/curriculum-compiler-json/compilers/question.js
+++ b/packages/curriculum-compiler-json/compilers/question.js
@@ -3,14 +3,14 @@ const {
   getAnswersFromNode,
 } = require('./helpers');
 
-module.exports = function question(node, type) {
-  if (!node.question) {
-    throw new Error(`Invalid question section ${node.name}`);
+module.exports = function question(section, type) {
+  if (!section.question) {
+    throw new Error(`Invalid question section ${section.name}`);
   }
-  const rawText = compileNodeToQuestionMarkdown(node);
-  const answers = getAnswersFromNode(node);
+  const rawText = compileNodeToQuestionMarkdown(section);
+  const answers = getAnswersFromNode(section);
   const q = compileNodeToQuestionMarkdown({
-    children: node.children.filter(
+    children: section.children.filter(
       child => child.type !== 'list' && !child.answers
     ),
   });

--- a/packages/curriculum-compiler-json/compilers/quiz.js
+++ b/packages/curriculum-compiler-json/compilers/quiz.js
@@ -4,18 +4,26 @@ const {
   compileNodeToMarkdown,
 } = require('./helpers');
 
-module.exports = function quiz(node) {
-  const rawText = compileNodeToQuestionMarkdown(node);
+module.exports = function quiz(section) {
+  if (!section.question) {
+    throw new Error(`Invalid question section ${section.name}`);
+  }
+  const rawText = compileNodeToQuestionMarkdown(section);
+
   const headline = compileNodeToMarkdown(
-    node.children.find(child => child.type === 'questionHeadline')
+    section.children.find(child => child.type === 'questionHeadline')
   )
     .split('\n')
     .join('');
-  const answers = getAnswersFromNode(node);
+
+  const answers = getAnswersFromNode(section);
 
   const question = compileNodeToQuestionMarkdown({
-    children: node.children.filter(
-      child => child.type !== 'questionHeadline' && !child.answers
+    children: section.children.filter(
+      child =>
+        child.type !== 'questionHeadline' &&
+        child.type !== 'list' &&
+        !child.answers
     ),
   });
 

--- a/packages/curriculum-parser-json/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-parser-json/__tests__/fixtures/insight/sample/ast.json
@@ -2,8 +2,7 @@
   "type": "root",
   "children": [
     {
-      "value":
-        "author: catalin\nlevels:\n  - basic\n  - medium\n  - advanced\ntype: normal\ncategory: must-know\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\ntags:\n  - introduction\n  - workout\nstub: false\nlinks:\n  - name: EnkiCool\n    url: 'https://enki.com'\n    nature: website\n",
+      "value": "author: catalin\nlevels:\n  - basic\n  - medium\n  - advanced\ntype: normal\ncategory: must-know\nstandards:\n  sql.use-dql.0: 10\n  sql.use-ddl.1: 1000\ntags:\n  - introduction\n  - workout\nstub: false\nlinks:\n  - name: EnkiCool\n    url: 'https://enki.com'\n    nature: website\n",
       "data": {
         "parsedValue": {
           "author": "catalin",
@@ -462,6 +461,15 @@
             {
               "type": "text",
               "value": "Sample quiz question"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "questionGap",
+              "value": "???"
             }
           ]
         },

--- a/packages/curriculum-parser-json/__tests__/fixtures/insight/sample/input.json
+++ b/packages/curriculum-parser-json/__tests__/fixtures/insight/sample/input.json
@@ -19,11 +19,9 @@
     ]
   },
   "headline": "Sample title with `code` within",
-  "content":
-    "This is a sample paragraph.[1]\n\nThis is a sample list[2]:\n\n* item one\n* item `two`\n\nSample code[3]:\n\n```javascript\nconsole.log('sample code')\n```\n",
+  "content": "This is a sample paragraph.[1]\n\nThis is a sample list[2]:\n\n* item one\n* item `two`\n\nSample code[3]:\n\n```javascript\nconsole.log('sample code')\n```\n",
   "practice": {
-    "rawText":
-      "This is a sample question with one gap:\n\n???\n\n* correct\n* incorrect\n* not a chance\n",
+    "rawText": "This is a sample question with one gap:\n\n???\n\n* correct\n* incorrect\n* not a chance\n",
     "question": "This is a sample question with one gap:\n\n???\n",
     "answers": [
       {
@@ -44,8 +42,7 @@
     ]
   },
   "revision": {
-    "rawText":
-      "This is a sample question with two gaps:\n\n???\n\n???\n\n* correct\n* also correct\n* nah bro\n* fam, just no\n",
+    "rawText": "This is a sample question with two gaps:\n\n???\n\n???\n\n* correct\n* also correct\n* nah bro\n* fam, just no\n",
     "question": "This is a sample question with two gaps:\n\n???\n\n???\n",
     "answers": [
       {
@@ -71,10 +68,9 @@
     ]
   },
   "quiz": {
-    "rawText":
-      "### Quiz title\n\n\nSample quiz question\n\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
+    "rawText": "### Quiz title\n\n\nSample quiz question\n\n???\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n",
     "headline": "Quiz title",
-    "question": "Sample quiz question\n",
+    "question": "Sample quiz question",
     "answers": [
       {
         "text": "correct",
@@ -99,8 +95,7 @@
     ]
   },
   "footnotes": {
-    "rawText":
-      "[1: Paragraph]\nSample explanation\n\n[2: List]\nSample list\n\n[3: Code]\nSample code\n\n```javascript\nvar x = 10\n```\n",
+    "rawText": "[1: Paragraph]\nSample explanation\n\n[2: List]\nSample list\n\n[3: Code]\nSample code\n\n```javascript\nvar x = 10\n```\n",
     "items": [
       {
         "number": "1",

--- a/packages/curriculum-parser-json/index.sandbox.js
+++ b/packages/curriculum-parser-json/index.sandbox.js
@@ -76,9 +76,9 @@ const json = {
   },
   quiz: {
     rawText:
-      '### Quiz title\n\n\nSample quiz question\n\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n',
+      '### Quiz title\n\n\nSample quiz question\n\n???\n* correct\n* *incorrect*\n* not a `chance`\n* nope\n',
     headline: 'Quiz title',
-    question: 'Sample quiz question\n',
+    question: 'Sample quiz question',
     answers: [
       {
         text: 'correct',

--- a/packages/curriculum-parser-json/package-lock.json
+++ b/packages/curriculum-parser-json/package-lock.json
@@ -225,40 +225,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@enkidevs/curriculum-helpers": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-3.0.1.tgz",
-			"integrity": "sha512-GidMrtSoCwGw1lnGgy/tPXfmGRymaZrw0DstqsmlwDND18Zf3v5aphKwFaFk+EjdPxO+L18X2IRBNPP+rtiYEw==",
-			"requires": {
-				"unist-util-map": "^1.0.3"
-			}
-		},
-		"@enkidevs/curriculum-parser-markdown": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-parser-markdown/-/curriculum-parser-markdown-4.0.1.tgz",
-			"integrity": "sha512-relPCJ2ONadst4xdxJ45SIRr5HDgKyqWCy39uJInhO9ZD2YQgQ10l3/ii3yWSF6erALem8MR5FNhWSkW1Q41Pg==",
-			"requires": {
-				"@enkidevs/curriculum-helpers": "^3.0.1",
-				"decode-uri-component": "^0.2.0",
-				"js-yaml": "^3.13.0",
-				"remark-frontmatter": "^1.3.1",
-				"remark-parse": "^6.0.3",
-				"unified": "^7.1.0",
-				"unist-builder": "^1.0.3",
-				"unist-util-map": "^1.0.3",
-				"unist-util-visit": "^1.4.0"
-			},
-			"dependencies": {
-				"unist-builder": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.4.tgz",
-					"integrity": "sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==",
-					"requires": {
-						"object-assign": "^4.1.0"
-					}
-				}
-			}
-		},
 		"@jest/console": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -493,40 +459,11 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"@types/node": {
-			"version": "11.11.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
-		},
-		"@types/unist": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
-		},
-		"@types/vfile": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
-			"integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
-			"requires": {
-				"@types/node": "*",
-				"@types/unist": "*",
-				"@types/vfile-message": "*"
-			}
-		},
-		"@types/vfile-message": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
-			"integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
-			"requires": {
-				"@types/node": "*",
-				"@types/unist": "*"
-			}
 		},
 		"@types/yargs": {
 			"version": "13.0.3",
@@ -769,11 +706,6 @@
 				"babel-plugin-jest-hoist": "^24.9.0"
 			}
 		},
-		"bail": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -999,21 +931,6 @@
 				"supports-color": "^5.3.0"
 			}
 		},
-		"character-entities": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
-		},
-		"character-entities-legacy": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
-		},
-		"character-reference-invalid": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
-		},
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1059,11 +976,6 @@
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
-		},
-		"collapse-white-space": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
-			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -1218,7 +1130,8 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -1518,7 +1431,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -1630,14 +1544,6 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"fault": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
-			"integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
-			"requires": {
-				"format": "^0.2.2"
-			}
-		},
 		"fb-watchman": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -1701,11 +1607,6 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -2484,7 +2385,8 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -2513,20 +2415,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"is-alphabetical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
-		},
-		"is-alphanumerical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -2582,11 +2470,6 @@
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
 			"dev": true
 		},
-		"is-decimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
-		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -2624,11 +2507,6 @@
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
 		},
-		"is-hexadecimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
-		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -2648,11 +2526,6 @@
 					}
 				}
 			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -2693,21 +2566,11 @@
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
-		"is-whitespace-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
-		},
-		"is-word-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
@@ -3502,11 +3365,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"markdown-escapes": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
-		},
 		"mdn-browser-compat-data": {
 			"version": "0.0.84",
 			"resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.84.tgz",
@@ -3915,19 +3773,6 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
-		"parse-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			}
-		},
 		"parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -4133,37 +3978,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"remark-frontmatter": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz",
-			"integrity": "sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==",
-			"requires": {
-				"fault": "^1.0.1",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-parse": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-			"integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
-			"requires": {
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^1.1.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^1.0.0",
-				"vfile-location": "^2.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4179,12 +3993,8 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.0",
@@ -4650,11 +4460,6 @@
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
-		"state-toggle": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
-		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4867,21 +4672,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-		},
-		"trim-trailing-lines": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
-		},
-		"trough": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4917,30 +4707,6 @@
 				"source-map": "~0.6.1"
 			}
 		},
-		"unherit": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
-			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"xtend": "^4.0.1"
-			}
-		},
-		"unified": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-			"integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"@types/vfile": "^3.0.0",
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-plain-obj": "^1.1.0",
-				"trough": "^1.0.0",
-				"vfile": "^3.0.0",
-				"x-is-string": "^0.1.0"
-			}
-		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4959,48 +4725,6 @@
 			"integrity": "sha512-EbTbog++1umb0PizmRDHd1Mm4qaRqRtTpvgd7DsHonwuvKY7ezykz0/jYMIt+ewmHc2+BYLg39gC49PDPe6yJA==",
 			"requires": {
 				"object-assign": "^4.1.0"
-			}
-		},
-		"unist-util-is": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-		},
-		"unist-util-map": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-1.0.5.tgz",
-			"integrity": "sha512-dFil/AN6vqhnQWNCZk0GF/G3+Q5YwsB+PqjnzvpO2wzdRtUJ1E8PN+XRE/PRr/G3FzKjRTJU0haqE0Ekl+O3Ag==",
-			"requires": {
-				"object-assign": "^4.0.1"
-			}
-		},
-		"unist-util-remove-position": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
-			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
-			"requires": {
-				"unist-util-visit": "^1.1.0"
-			}
-		},
-		"unist-util-stringify-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
-		},
-		"unist-util-visit": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-			"requires": {
-				"unist-util-visit-parents": "^2.0.0"
-			}
-		},
-		"unist-util-visit-parents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-			"requires": {
-				"unist-util-is": "^3.0.0"
 			}
 		},
 		"universalify": {
@@ -5105,37 +4829,6 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
-			}
-		},
-		"vfile": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
-			"integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
-			"requires": {
-				"is-buffer": "^2.0.0",
-				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^1.0.0",
-				"vfile-message": "^1.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-				}
-			}
-		},
-		"vfile-location": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
-			"integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ=="
-		},
-		"vfile-message": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
-			"requires": {
-				"unist-util-stringify-position": "^1.1.1"
 			}
 		},
 		"w3c-hr-time": {
@@ -5246,21 +4939,11 @@
 				"async-limiter": "~1.0.0"
 			}
 		},
-		"x-is-string": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-			"integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
-		},
 		"xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/insight/sample/ast.json
@@ -3,8 +3,7 @@
   "children": [
     {
       "type": "yaml",
-      "value":
-        "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n    - >-\n        [Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}\n\nparent: removing-keys-from-a-binary-search-tree",
+      "value": "author: jfarmer\n\nlevels:\n\n  - beginner\n  - basic\n  - medium\n  - advanced\n\ntype: normal\n\ncategory: must-know\n\nlinks:\n    - >-\n        [Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}\n\nparent: removing-keys-from-a-binary-search-tree",
       "data": {
         "parsedValue": {
           "author": "jfarmer",
@@ -14,8 +13,7 @@
           "links": [
             {
               "name": "Why is it safer to keep the tree balanced?",
-              "url":
-                "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
+              "url": "http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree",
               "nature": "website"
             }
           ],
@@ -54,8 +52,7 @@
             },
             {
               "type": "text",
-              "value":
-                " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application."
+              "value": " if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases \"approximately the same\" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application."
             }
           ]
         },
@@ -64,8 +61,7 @@
           "children": [
             {
               "type": "text",
-              "value":
-                "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree."
+              "value": "This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree."
             }
           ]
         },
@@ -74,8 +70,7 @@
           "children": [
             {
               "type": "text",
-              "value":
-                "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:"
+              "value": "Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:"
             }
           ]
         },
@@ -85,8 +80,7 @@
             {
               "type": "image",
               "title": null,
-              "url":
-                "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
               "alt": "unbalanced",
               "svg": true
             }
@@ -115,8 +109,7 @@
             {
               "type": "image",
               "title": null,
-              "url":
-                "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
+              "url": "%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E",
               "alt": "balanced",
               "svg": true
             }
@@ -127,8 +120,7 @@
           "children": [
             {
               "type": "text",
-              "value":
-                "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching "
+              "value": "This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching "
             },
             {
               "type": "emphasis",
@@ -150,8 +142,7 @@
           "children": [
             {
               "type": "text",
-              "value":
-                "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees"
+              "value": "Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees"
             },
             {
               "type": "linkReference",
@@ -324,6 +315,15 @@
           "value": "#!/bin/bash\na=1\n{ a=2 }\necho $a"
         },
         {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "questionGap",
+              "value": "???"
+            }
+          ]
+        },
+        {
           "type": "list",
           "ordered": false,
           "start": null,
@@ -424,8 +424,7 @@
             },
             {
               "type": "text",
-              "value":
-                "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one."
+              "value": "\nSelf-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one."
             }
           ]
         },
@@ -446,8 +445,7 @@
             },
             {
               "type": "text",
-              "value":
-                "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black."
+              "value": "\nSelf-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black."
             }
           ]
         }

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/insight/sample/text.md
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/insight/sample/text.md
@@ -65,6 +65,8 @@ a=1
 echo $a
 ```
 
+???
+
 * "Error: unexpected end of file"
 * 1
 * 2

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/question/error/invalid-question-answers.md
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/question/error/invalid-question-answers.md
@@ -1,0 +1,8 @@
+What are the answers?
+
+```bash
+a = ???
+b = ???
+```
+
+* `1`

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/question/quiz/ast.json
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/question/quiz/ast.json
@@ -20,6 +20,15 @@
       ]
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "questionGap",
+          "value": "???"
+        }
+      ]
+    },
+    {
       "type": "list",
       "ordered": false,
       "start": null,

--- a/packages/curriculum-parser-markdown/__tests__/fixtures/question/quiz/text.md
+++ b/packages/curriculum-parser-markdown/__tests__/fixtures/question/quiz/text.md
@@ -3,6 +3,8 @@
 Consider a complete, weighted graph. If we want to compute its minimum spanning tree,
 which starts from a given node we choose, which algorithm should we use?
 
+???
+
 * Prim’s algorithm
 * Kruskal’s algorithm
 * Knapsack algorithm

--- a/packages/curriculum-parser-markdown/__tests__/question/error-question.test.js
+++ b/packages/curriculum-parser-markdown/__tests__/question/error-question.test.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const fs = require('fs');
+const { contentTypes } = require('@enkidevs/curriculum-helpers');
+const { getParser } = require('../..');
+
+describe('Fail insight question parsing', () => {
+  describe('Fail for insights with invalid question answers', () => {
+    const text = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../',
+        'fixtures',
+        'question',
+        'error',
+        'invalid-question-answers.md'
+      ),
+      'utf8'
+    );
+
+    let parser;
+
+    beforeEach(() => {
+      parser = getParser(contentTypes.QUESTION);
+    });
+
+    test('parseSync should throw on invalid question answers', () => {
+      expect(() => {
+        parser.parseSync(text);
+      }).toThrow();
+    });
+
+    test('parse should throw on invalid question answers', async () => {
+      expect.assertions(1);
+      await expect(parser.parse(text)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/curriculum-parser-markdown/index.sandbox.js
+++ b/packages/curriculum-parser-markdown/index.sandbox.js
@@ -2,86 +2,16 @@
 const parser = require('./index');
 const { compactAst } = require('../curriculum-helpers');
 
-const ast = parser.getParser('insight').parseSync(`---
-author: jfarmer
-
-levels:
-
-  - beginner
-  - basic
-  - medium
-  - advanced
-
-type: normal
-
-category: must-know
-
-links:
-    - >-
-        [Why is it safer to keep the tree balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}
-
-parent: removing-keys-from-a-binary-search-tree
----
-
-# Balanced vs. Unbalanced Binary Trees
-
----
-## Content
-
-A binary tree is called *balanced* if every leaf node is not more than a certain distance away from the root than any other leaf.  That is, if we take any two leaf nodes (including empty nodes), the distance between each node and the root is approximately the same.  In most cases "approximately the same" means the distance between the leaf and the root is not greater than 1, but the exact number can vary from application to application.
-
-This distance constraint ensures that it takes approximately the same amount of time to reach any leaf node in a binary tree from the root. A linked list is a kind of maximally-unbalanced binary tree.
-
-Consider the following unbalanced tree. The nodes that can be swapped to balance the tree are highlighted:
-
-![unbalanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2095c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2031.6072003%20362.551767%2025%20350%2025c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20131.6072%20222.551767%20125%20210%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20232.6072%20112.551767%20226%20100%20226c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20195c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20131.6072%20502.551767%20125%20490%20125c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22174%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22177%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20296c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20232.6072%20612.551767%20226%20600%20226c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22277%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M535%20375c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C558.560339%20311.6072%20547.551767%20305%20535%20305c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22510.996094%22%20y%3D%22356%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22277%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2276%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2085L232%20131.270754M376%2085l89.005263%2049.575516M125%20236.675909L185.724368%20186M516%20185l60.148477%2050.16054M561%20315.334131L575.702837%20285%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)
-
-In order to balance the above tree, the \`10-15-13\` subtree has to be "rotated":
-
-![balanced](%3Csvg%20width%3D%22100%25%22%20height%3D%22auto%22%20viewBox%3D%220%200%20700%20300%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EArtboard%3C%2Ftitle%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M350%2085c19.329966%200%2035-15.6700338%2035-35%200-6.7781994-1.926799-13.1063707-5.262556-18.4666731C373.560339%2021.6072003%20362.551767%2015%20350%2015c-19.329966%200-35%2015.6700338-35%2035s15.670034%2035%2035%2035zM210%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C233.560339%20121.6072%20222.551767%20115%20210%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035zM100%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C123.560339%20222.6072%20112.551767%20216%20100%20216c-19.3299662%200-35%2015.670034-35%2035s15.6700338%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3Cpath%20d%3D%22M490%20185c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C513.560339%20121.6072%20502.551767%20115%20490%20115c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22465.996094%22%20y%3D%22164%22%3E13%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22197.998047%22%20y%3D%22167%22%3E3%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M600%20286c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C623.560339%20222.6072%20612.551767%20216%20600%20216c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22575.996094%22%20y%3D%22267%22%3E15%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M380%20285c19.329966%200%2035-15.670034%2035-35%200-6.778199-1.926799-13.106371-5.262556-18.466673C403.560339%20221.6072%20392.551767%20215%20380%20215c-19.329966%200-35%2015.670034-35%2035s15.670034%2035%2035%2035z%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20fill%3D%22%23FFF%22%2F%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22355.996094%22%20y%3D%22266%22%3E10%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%2287.9980469%22%20y%3D%22267%22%3E1%3C%2Ftspan%3E%3C%2Ftext%3E%3Ctext%20font-family%3D%22RobotoMono-Light%2C%20Roboto%20Mono%22%20font-size%3D%2240%22%20font-weight%3D%22300%22%20fill%3D%22currentColor%22%3E%3Ctspan%20x%3D%22337.998047%22%20y%3D%2266%22%3E8%3C%2Ftspan%3E%3C%2Ftext%3E%3Cpath%20d%3D%22M325.305402%2075L232%20121.270754M376%2075l89.005263%2049.575516M125%20226.675909L185.724368%20176M516%20175l60.148477%2050.16054M405%20224.911949L464.957392%20175%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E)
-
-
-This is a problem for binary search trees (BSTs) because an ordered linked list is a BST and searching it is linear. Thus, a BST has log-time searching *on average*, but a linear-time worst case.
-
-Solving this problem and guaranteeing that the tree remains more-or-less balanced is one of the main motivations behind more complex BST-like data structures, e.g. AVL trees[1] and red-black trees[2].
-
+const ast = parser.getParser('question').parseSync(`
 ---
 ## Revision
 
-Which of the following data structures is a type of *maximally-unbalanced* binary tree?
+What are the answers?
 
-???
+a = ???
+b = ???
 
-* Ordered linked list
-* Ordered array
-* Weighted graph
-* Max-heap
-
----
-## Quiz
-
-### what is the output of the following script?
-
-\`\`\`bash
-#!/bin/bash
-a=1
-{ a=2 }
-echo $a
-\`\`\`
-
-* "Error: unexpected end of file"
 * 1
-* 2
-* $a
-
----
-## Footnotes
-
-[1: AVL tree]
-Self-balancing binary search tree, in which the height of the two child subtrees of any node differ by at most one.
-
-[2: Red-Black tree]
-Self-balancing binary search tree, in which nodes store an additional bit of data: whether the node is black or red. All of the tree's leaves must be black and, in case of a node being red, its two children must be black.
 `);
 
 process.stdout.write(JSON.stringify(compactAst(ast), null, 2));

--- a/packages/curriculum-parser-markdown/jest.config.js
+++ b/packages/curriculum-parser-markdown/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  testEnvironment: 'node',
   testRegex: '.*/__tests__/.*\\.test.js$',
   collectCoverageFrom: [
     '**/*.{js,jsx}',

--- a/packages/curriculum-parser-markdown/package-lock.json
+++ b/packages/curriculum-parser-markdown/package-lock.json
@@ -226,9 +226,9 @@
 			}
 		},
 		"@enkidevs/curriculum-helpers": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-3.0.1.tgz",
-			"integrity": "sha512-GidMrtSoCwGw1lnGgy/tPXfmGRymaZrw0DstqsmlwDND18Zf3v5aphKwFaFk+EjdPxO+L18X2IRBNPP+rtiYEw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-4.0.0.tgz",
+			"integrity": "sha512-i0+fNEOEIZRAnQZv3+RvoGJ0zJWOBQEcVqr5twu+UoHNg3u3PKUDcM0fwEa3K9pnD6FJhsxZNueH48XsaHLZLA==",
 			"requires": {
 				"unist-util-map": "^1.0.3"
 			}

--- a/packages/curriculum-parser-markdown/package.json
+++ b/packages/curriculum-parser-markdown/package.json
@@ -42,7 +42,6 @@
     "remark-parse": "^7.0.1",
     "unified": "^8.4.1",
     "unist-builder": "^2.0.0",
-    "unist-util-map": "^1.0.3",
     "unist-util-visit": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/curriculum-parser-markdown/plugins/insight/headline.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/headline.js
@@ -1,19 +1,21 @@
-const map = require('unist-util-map');
+const visit = require('unist-util-visit');
 
 module.exports = function headline() {
   return transform;
 
   function transform(ast) {
-    return map(ast, parseHeadline);
+    visit(ast, isH1, parseHeadline);
+    return ast;
   }
 
-  function parseHeadline(node) {
-    if (node.type === 'heading' && node.depth === 1) {
-      return {
-        type: 'headline',
-        children: node.children,
-      };
-    }
-    return node;
+  function isH1(node) {
+    return node.type === 'heading' && node.depth === 1;
+  }
+
+  function parseHeadline(node, index, parent) {
+    parent.children[index] = {
+      type: 'headline',
+      children: node.children,
+    };
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/insight/image.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/image.js
@@ -1,23 +1,20 @@
-const map = require('unist-util-map');
+const visit = require('unist-util-visit');
 const decode = require('decode-uri-component');
 
 module.exports = function image() {
   return transform;
 
   function transform(ast) {
-    return map(ast, parseImage);
+    visit(ast, 'image', parseImage);
+    return ast;
   }
 
   function parseImage(node) {
-    if (node.type === 'image') {
-      const decodedUrl = decode(node.url);
-      if (decodedUrl.startsWith('<svg')) {
-        return {
-          ...node,
-          svg: true,
-        };
-      }
+    const decodedUrl = decode(node.url);
+    if (decodedUrl.startsWith('<svg')) {
+      Object.assign(node, {
+        svg: true,
+      });
     }
-    return node;
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/insight/section.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/section.js
@@ -15,8 +15,8 @@ module.exports = function section() {
       if (
         !(
           current.type === 'thematicBreak' &&
-          (next || {}).type === 'heading' &&
-          (next || {}).depth === 2
+          (next || { type: '' }).type === 'heading' &&
+          (next || { depth: NaN }).depth === 2
         )
       ) {
         if (sec) {

--- a/packages/curriculum-parser-markdown/plugins/insight/validators/headline.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/validators/headline.js
@@ -1,20 +1,21 @@
 const visit = require('unist-util-visit');
 
-module.exports = function headline() {
-  let headlineNodeCount = 0;
-
+module.exports = function validateHeadline() {
   return transform;
 
   function transform(ast) {
-    visit(ast, 'headline', validateHeadline);
+    let headlineNodeCount = 0;
+
+    visit(ast, 'headline', () => {
+      headlineNodeCount += 1;
+    });
+
     if (headlineNodeCount !== 1) {
       throw new Error(
         `Must have exactly 1 headline but found ${headlineNodeCount} instead.`
       );
     }
-  }
 
-  function validateHeadline() {
-    headlineNodeCount += 1;
+    return ast;
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/insight/validators/section.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/validators/section.js
@@ -4,20 +4,20 @@ const { sectionNames } = require('@enkidevs/curriculum-helpers');
 const validSectionNames = Object.values(sectionNames);
 const validSectionNamesSet = new Set(validSectionNames);
 
-module.exports = function headline() {
+module.exports = function validateSection() {
   return transform;
 
   function transform(ast) {
-    visit(ast, 'section', validateSection);
-  }
+    visit(ast, 'section', ({ name }) => {
+      if (!validSectionNamesSet.has(name)) {
+        throw new Error(
+          `Section name "${name}" is invalid. Only valid options are ["${validSectionNames.join(
+            '", "'
+          )}"]`
+        );
+      }
+    });
 
-  function validateSection({ name }) {
-    if (!validSectionNamesSet.has(name)) {
-      throw new Error(
-        `Section name "${name}" is invalid. Only valid options are ["${validSectionNames.join(
-          '", "'
-        )}"]`
-      );
-    }
+    return ast;
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/insight/validators/yaml.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/validators/yaml.js
@@ -1,20 +1,21 @@
 const visit = require('unist-util-visit');
 
-module.exports = function yaml() {
-  let yamlNodeCount = 0;
-
+module.exports = function validateYaml() {
   return transform;
 
   function transform(ast) {
-    visit(ast, 'yaml', validateYaml);
+    let yamlNodeCount = 0;
+
+    visit(ast, 'yaml', () => {
+      yamlNodeCount += 1;
+    });
+
     if (yamlNodeCount !== 1) {
       throw new Error(
         `Must have exactly 1 yaml configuration but found ${yamlNodeCount} instead.`
       );
     }
-  }
 
-  function validateYaml() {
-    yamlNodeCount += 1;
+    return ast;
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/insight/yaml.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/yaml.js
@@ -1,27 +1,29 @@
-const map = require('unist-util-map');
+const visit = require('unist-util-visit');
 const jsYaml = require('js-yaml');
 
 module.exports = function yaml() {
   return transform;
 
   function transform(ast) {
-    return map(ast, node => {
-      if (node.type === 'yaml') {
-        const parsedValue = jsYaml.safeLoad(node.value, 'utf8');
-        const newNode = {
-          ...node,
-          data: {
-            parsedValue,
-          },
-        };
-        const { links } = parsedValue;
-        if (Array.isArray(links)) {
-          newNode.data.parsedValue.links = links.map(getMarkdownLink);
-        }
-        return newNode;
-      }
-      return node;
-    });
+    visit(ast, 'yaml', parseYaml);
+    return ast;
+  }
+
+  function parseYaml(node) {
+    const parsedValue = jsYaml.safeLoad(node.value, 'utf8');
+    const newNode = {
+      ...node,
+      data: {
+        parsedValue,
+      },
+    };
+
+    const { links } = parsedValue;
+    if (Array.isArray(links)) {
+      newNode.data.parsedValue.links = links.map(getMarkdownLink);
+    }
+
+    Object.assign(node, newNode);
   }
 };
 

--- a/packages/curriculum-parser-markdown/plugins/insight/yaml.js
+++ b/packages/curriculum-parser-markdown/plugins/insight/yaml.js
@@ -32,15 +32,16 @@ const mdUrlRegEx = /\[(.*)\]\((.*)\)/;
 const mdUrlRegExWithType = /\[(.*)\]\((.*)\)\{(.*)\}/;
 
 function getMarkdownLink(link) {
-  let result;
   if (mdUrlRegExWithType.test(link)) {
-    result = mdUrlRegExWithType.exec(link);
-    return { name: result[1], url: result[2], nature: result[3] };
+    const [, name, url, nature] = mdUrlRegExWithType.exec(link);
+    return { name, url, nature };
   }
+
   if (mdUrlRegEx.test(link)) {
-    result = mdUrlRegEx.exec(link);
-    return { name: result[1], url: result[2], nature: 'website' };
+    const [, name, url] = mdUrlRegEx.exec(link);
+    return { name, url, nature: 'website' };
   }
+
   return {
     nature: 'website',
     name: getDomainFromURL(link),
@@ -50,19 +51,10 @@ function getMarkdownLink(link) {
 
 // http://stackoverflow.com/questions/8498592/extract-root-domain-name-from-string
 function getDomainFromURL(url) {
-  if (url) {
-    let domain;
-    // find & remove protocol (http, ftp, etc.) and get domain
-    if (url.indexOf('://') > -1) {
-      domain = url.split('/')[2];
-    } else {
-      domain = url.split('/');
-    }
-
-    // find & remove port number
-    domain = domain.split(':');
-
-    return domain;
-  }
-  return null;
+  return url
+    ? // find & remove protocol (http, ftp, etc.) and get domain
+      (url.indexOf('://') > -1 ? url.split('/')[2] : url.split('/'))
+        // find & remove port number
+        .split(':')
+    : null;
 }

--- a/packages/curriculum-parser-markdown/plugins/question/answers.js
+++ b/packages/curriculum-parser-markdown/plugins/question/answers.js
@@ -1,55 +1,32 @@
-const map = require('unist-util-map');
 const visit = require('unist-util-visit');
 
 module.exports = function questionAnswers() {
   return transform;
 
   function transform(ast) {
-    const temp = { questionGapCount: 0 };
-    ast = map(ast, parseQuestionAnswersList(temp));
-    ast = map(ast, parseQuestionAnswersListItems(temp));
+    visit(ast, isQuestionAnswers, parseQuestionAnswers);
     return ast;
   }
 
-  function parseQuestionAnswersList(temp) {
-    return function one(node, index, parent) {
-      if (
-        node.type === 'list' &&
-        !node.ordered &&
-        index === parent.children.length - 1 &&
-        (parent.type === 'root' ||
-          (parent.type === 'section' && parent.question))
-      ) {
-        visit(parent, 'questionGap', () => {
-          temp.questionGapCount += 1;
-        });
-
-        return { ...node, answers: true };
-      }
-      return node;
-    };
+  function isQuestionAnswers(node, index, parent) {
+    return (
+      node.type === 'list' &&
+      !node.ordered &&
+      index === parent.children.length - 1 &&
+      (parent.type === 'root' || (parent.type === 'section' && parent.question))
+    );
   }
 
-  function parseQuestionAnswersListItems(temp) {
-    return function one(node, index, parent) {
-      if (
-        node.type === 'listItem' &&
-        parent.type === 'list' &&
-        parent.answers
-      ) {
-        const correct = getCorrectAndUpdateCount(temp, index);
-        return { ...node, correct };
-      }
-      return node;
-    };
-  }
+  function parseQuestionAnswers(node, index, parent) {
+    let expectedAnswersCount = 0;
+    visit(parent, 'questionGap', () => {
+      expectedAnswersCount += 1;
+    });
 
-  function getCorrectAndUpdateCount(temp, index) {
-    let correct = index === 0;
-    if (temp.questionGapCount > 0) {
-      correct = true;
-      temp.questionGapCount -= 1;
-    }
-    return correct;
+    node.answers = true;
+    node.children = node.children.map((child, i) => ({
+      ...child,
+      correct: i <= expectedAnswersCount - 1,
+    }));
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/question/code.js
+++ b/packages/curriculum-parser-markdown/plugins/question/code.js
@@ -1,43 +1,44 @@
-const map = require('unist-util-map');
+const visit = require('unist-util-visit');
 const u = require('unist-builder');
 
 module.exports = function questionCode() {
   return transform;
 
   function transform(ast) {
-    return map(ast, parseCode);
+    visit(ast, isQuestionCode, parseQuestionCode);
+    return ast;
   }
 
-  function parseCode(node) {
-    if (node.type === 'code' && node.value.includes('???')) {
-      return {
-        ...node,
-        type: 'questionCode',
-        children: node.value.split('\n').map(line =>
-          u(
-            'questionCodeLine',
-            undefined,
-            line
-              .split(/(\?{3})/) // split using a group so we also capture ???
-              .map(chunk =>
-                chunk === '???'
-                  ? u('questionGap', undefined, '???')
-                  : u('questionCodeSegment', { lang: node.lang }, chunk)
-              )
-              .filter(n => Boolean(n.value)) // eliminate empty string nodes
-              .reduce((lineChildren, curr, i) => {
-                const prev = lineChildren[i - 1];
-                if (prev && prev.type === 'text' && prev.type === curr.type) {
-                  prev.value += curr.value;
-                } else {
-                  lineChildren.push(curr);
-                }
-                return lineChildren;
-              }, [])
-          )
-        ),
-      };
-    }
-    return node;
+  function isQuestionCode(node) {
+    return node.type === 'code' && node.value.includes('???');
+  }
+
+  function parseQuestionCode(node) {
+    Object.assign(node, {
+      type: 'questionCode',
+      children: node.value.split('\n').map(line =>
+        u(
+          'questionCodeLine',
+          undefined,
+          line
+            .split(/(\?{3})/) // split using a group so we also capture ???
+            .map(chunk =>
+              chunk === '???'
+                ? u('questionGap', undefined, '???')
+                : u('questionCodeSegment', { lang: node.lang }, chunk)
+            )
+            .filter(n => Boolean(n.value)) // eliminate empty string nodes
+            .reduce((lineChildren, curr, i) => {
+              const prev = lineChildren[i - 1];
+              if (prev && prev.type === 'text' && prev.type === curr.type) {
+                prev.value += curr.value;
+              } else {
+                lineChildren.push(curr);
+              }
+              return lineChildren;
+            }, [])
+        )
+      ),
+    });
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/question/headline.js
+++ b/packages/curriculum-parser-markdown/plugins/question/headline.js
@@ -1,23 +1,25 @@
-const map = require('unist-util-map');
+const visit = require('unist-util-visit');
 
 module.exports = function questionHeadline() {
   return transform;
 
   function transform(ast) {
-    return map(ast, parseHeadline);
+    visit(ast, isHeadline, createHeadline);
+    return ast;
   }
 
-  function parseHeadline(node, index, parent) {
-    if (
+  function isHeadline(node, index, parent) {
+    return (
       node.type === 'heading' &&
       node.depth === 3 &&
       (parent.type === 'root' || (parent.type === 'section' && parent.question))
-    ) {
-      return {
-        type: 'questionHeadline',
-        children: node.children,
-      };
-    }
-    return node;
+    );
+  }
+
+  function createHeadline(node, index, parent) {
+    parent.children[index] = {
+      type: 'questionHeadline',
+      children: node.children,
+    };
   }
 };

--- a/packages/curriculum-parser-markdown/plugins/question/index.js
+++ b/packages/curriculum-parser-markdown/plugins/question/index.js
@@ -2,5 +2,12 @@ const questionAnswers = require('./answers');
 const questionCode = require('./code');
 const questionGap = require('./gap');
 const questionHeadline = require('./headline');
+const validators = require('./validators');
 
-module.exports = [questionHeadline, questionGap, questionCode, questionAnswers];
+module.exports = [
+  questionHeadline,
+  questionGap,
+  questionCode,
+  questionAnswers,
+  ...validators,
+];

--- a/packages/curriculum-parser-markdown/plugins/question/validators/answers.js
+++ b/packages/curriculum-parser-markdown/plugins/question/validators/answers.js
@@ -1,0 +1,62 @@
+const visit = require('unist-util-visit');
+
+module.exports = function validateQuestionAnswers() {
+  return transform;
+
+  function transform(ast) {
+    visit(ast, isQuestionSection, validate);
+    return ast;
+  }
+
+  function isQuestionSection(node) {
+    return (
+      (node.type === 'section' && node.question) ||
+      (node.type === 'root' && node.children.some(child => child.answers))
+    );
+  }
+
+  function validate(section) {
+    const answers = section.children.find(
+      child => child.type === 'list' && child.answers
+    );
+
+    if (!answers) {
+      throw new Error(
+        `Missing question answers${
+          section.name ? ` for the "${section.name}" section` : ''
+        }.`
+      );
+    }
+
+    const sectionChildrenWithoutAnswers = section.children.filter(
+      child => child !== answers
+    );
+
+    let questionGapCount = 0;
+
+    visit(
+      {
+        ...section,
+        children: sectionChildrenWithoutAnswers,
+      },
+      'questionGap',
+      () => {
+        questionGapCount += 1;
+      }
+    );
+
+    const correctAnswersCount = answers.children.filter(
+      listItem => listItem.correct
+    ).length;
+
+    if (questionGapCount !== correctAnswersCount) {
+      throw new Error(
+        `Missing answers for${
+          section.name ? ` ${section.name}` : ''
+        } question. There are ${
+          questionGapCount > correctAnswersCount ? 'more' : 'less'
+        } question gaps (${questionGapCount}) than correct answers (${correctAnswersCount})`
+      );
+    }
+  }
+};

--- a/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
+++ b/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
@@ -23,6 +23,7 @@ module.exports = function validateQuestionGap() {
     });
 
     if (questionGapCount === 0) {
+      console.log(JSON.stringify(section));
       throw new Error(
         `${section.name} question does not have any question gaps.`
       );

--- a/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
+++ b/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
@@ -1,0 +1,28 @@
+const visit = require('unist-util-visit');
+
+module.exports = function validateQuestionGap() {
+  return transform;
+
+  function transform(ast) {
+    visit(ast, isQuestionSection, validate);
+    return ast;
+  }
+
+  function isQuestionSection(node) {
+    return (node.type === 'section' && node.question) || node.type === 'root';
+  }
+
+  function validate(section) {
+    let questionGapCount = 0;
+
+    visit(section, 'questionGap', () => {
+      questionGapCount += 1;
+    });
+
+    if (questionGapCount === 0) {
+      throw new Error(
+        `${section.name} question does not have any question gaps.`
+      );
+    }
+  }
+};

--- a/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
+++ b/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
@@ -23,7 +23,6 @@ module.exports = function validateQuestionGap() {
     });
 
     if (questionGapCount === 0) {
-      console.log(JSON.stringify(section));
       throw new Error(
         `${section.name} question does not have any question gaps.`
       );

--- a/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
+++ b/packages/curriculum-parser-markdown/plugins/question/validators/gap.js
@@ -9,7 +9,10 @@ module.exports = function validateQuestionGap() {
   }
 
   function isQuestionSection(node) {
-    return (node.type === 'section' && node.question) || node.type === 'root';
+    return (
+      (node.type === 'section' && node.question) ||
+      (node.type === 'root' && node.children.some(child => child.answers))
+    );
   }
 
   function validate(section) {

--- a/packages/curriculum-parser-markdown/plugins/question/validators/index.js
+++ b/packages/curriculum-parser-markdown/plugins/question/validators/index.js
@@ -1,0 +1,4 @@
+const answers = require('./answers');
+const gap = require('./gap');
+
+module.exports = [gap, answers];


### PR DESCRIPTION
### Parser fixes

- [x] :muscle: add question gap count validation (# of `???` must be > 0). 

- [x] :muscle: add question answer validation (# of answers must === # of `???`). 

- [x] :bug: fix the bug with the `correct` flag on question answers not being extracted correctly. It was polluted by question gaps from other questions, because the plugin code wasn't limiting its search only to the question string at hand but also including its siblings, which would sometimes mark more answers as `correct` than it was actually correct. 

- [x] :package: switch all plugins to use `unist-util-visit` and remove the now unused dependency `unist-util-map`. This means that all plugins are now modifying the AST in place rather than some creating a new one with their logic. Since enforcing generalized immutability was not necessary, we switched to full mutability for efficiency (and simplicity) reasons. 

- [x] ✅ Make sure jest runs in `node` environment - otherwise we could have bugs such as having accidentally omitted unifiedjs transform variables like `parent` point to mocked `window` object instead of being `undefined`