### PR TITLE
Fix JSON parser footnotes bug

### DIFF
--- a/packages/curriculum-compiler-json/compilers/footnotes.js
+++ b/packages/curriculum-compiler-json/compilers/footnotes.js
@@ -12,7 +12,7 @@ module.exports = function footnotes(node) {
 };
 
 function parseRawFootnotes(text) {
-  const splitTextArray = text.split(/(\[.*:.*\])/gi).filter(Boolean);
+  const splitTextArray = text.split(/(\[\d+:.*\])/gi).filter(Boolean);
   // eslint-disable-next-line max-params
   return splitTextArray.reduce((items, line, index, array) => {
     if (index % 2 === 1) {


### PR DESCRIPTION
Because we make the footnote counter fully optional, the parser would break on some footnotes that contain markdown links:

<img width="903" alt="Screen Shot 2020-04-28 at 1 35 10 AM" src="https://user-images.githubusercontent.com/9661806/80450973-bd703f00-88f0-11ea-9e64-bbadd5f0ea9d.png">

After the fix:

<img width="903" alt="Screen Shot 2020-04-28 at 1 37 05 AM" src="https://user-images.githubusercontent.com/9661806/80451005-ccef8800-88f0-11ea-955d-b8bfd59e6aef.png">
