### PR TITLE
Match convention of using rawText for content and headline

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,4 @@
 {
-  "lerna": "2.8.0",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "independent"
 }

--- a/packages/curriculum-ast-validators/package-lock.json
+++ b/packages/curriculum-ast-validators/package-lock.json
@@ -401,30 +401,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@enkidevs/curriculum-helpers": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-7.0.0.tgz",
-      "integrity": "sha512-bTxQaI+HThUMe2NtQdacHXFf5UWzQxJJYADi2mPT+oBK1F68Y5fgeysqb0VHvWggBvBv3HAjjLI+gjy22ttxTw==",
-      "requires": {
-        "unist-util-map": "^2.0.0"
-      }
-    },
-    "@enkidevs/curriculum-parser-markdown": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@enkidevs/curriculum-parser-markdown/-/curriculum-parser-markdown-7.0.0.tgz",
-      "integrity": "sha512-pbsPCZTGTLbaw+/u+TcJqJUS8fhje/tPYxpYIdhxndu910+tOZTxe1RDwSOulrYeIi6tCPBsw9fWkQQRhs9RCw==",
-      "dev": true,
-      "requires": {
-        "@enkidevs/curriculum-helpers": "^7.0.0",
-        "decode-uri-component": "^0.2.0",
-        "js-yaml": "^3.13.0",
-        "remark-frontmatter": "^1.3.1",
-        "remark-parse": "^7.0.1",
-        "unified": "^9.0.0",
-        "unist-builder": "^2.0.0",
-        "unist-util-visit": "^2.0.0"
-      }
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -698,14 +674,6 @@
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
-      }
-    },
-    "@types/mdast": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-      "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-      "requires": {
-        "@types/unist": "*"
       }
     },
     "@types/normalize-package-data": {
@@ -991,12 +959,6 @@
         "babel-preset-current-node-syntax": "^0.1.2"
       }
     },
-    "bail": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1178,24 +1140,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "dev": true
-    },
-    "character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "dev": true
-    },
-    "character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "dev": true
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1240,12 +1184,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "collapse-white-space": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -1772,15 +1710,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fault": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-      "dev": true,
-      "requires": {
-        "format": "^0.2.0"
-      }
-    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -1831,12 +1760,6 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
-    },
-    "format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
-      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -2120,32 +2043,10 @@
         }
       }
     },
-    "is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "dev": true
-    },
-    "is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "dev": true,
-      "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
       "dev": true
     },
     "is-ci": {
@@ -2182,12 +2083,6 @@
           }
         }
       }
-    },
-    "is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -2226,22 +2121,10 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
-    "is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "dev": true
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
     "is-plain-object": {
@@ -2265,22 +2148,10 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-whitespace-character": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-      "dev": true
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
-    },
-    "is-word-character": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
       "dev": true
     },
     "is-wsl": {
@@ -3059,12 +2930,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-escapes": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-      "dev": true
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3260,11 +3125,6 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3387,20 +3247,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
-    },
-    "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "dev": true,
-      "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
     },
     "parse-json": {
       "version": "5.0.0",
@@ -3609,39 +3455,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "remark-frontmatter": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz",
-      "integrity": "sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==",
-      "dev": true,
-      "requires": {
-        "fault": "^1.0.1",
-        "xtend": "^4.0.1"
-      }
-    },
-    "remark-parse": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.2.tgz",
-      "integrity": "sha512-9+my0lQS80IQkYXsMA8Sg6m9QfXYJBnXjWYN5U+kFc5/n69t+XZVXU/ZBYr3cYH8FheEGf1v87rkFDhJ8bVgMA==",
-      "dev": true,
-      "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -3658,12 +3471,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
-    "replace-ext": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
       "dev": true
     },
     "request": {
@@ -4291,12 +4098,6 @@
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
-    "state-toggle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-      "dev": true
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4522,24 +4323,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
-    },
-    "trim-trailing-lines": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
-      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
-      "dev": true
-    },
-    "trough": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4585,30 +4368,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "unherit": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "unified": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
-      "integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
-      "dev": true,
-      "requires": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-buffer": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
-        "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      }
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4621,69 +4380,10 @@
         "set-value": "^2.0.1"
       }
     },
-    "unist-builder": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
-      "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==",
-      "dev": true
-    },
     "unist-util-is": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.1.tgz",
       "integrity": "sha512-7NYjErP4LJtkEptPR22wO5RsCPnHZZrop7t2SoQzjvpFedCFer4WW8ujj9GI5DkUX7yVcffXLjoURf6h2QUv6Q=="
-    },
-    "unist-util-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-2.0.1.tgz",
-      "integrity": "sha512-VdNvk4BQUUU9Rgr8iUOvclHa/iN9O+6Dt66FKij8l9OVezGG37gGWCPU5KSax1R2degqXFvl3kWTkvzL79e9tQ==",
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "object-assign": "^4.0.0"
-      }
-    },
-    "unist-util-remove-position": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-      "dev": true,
-      "requires": {
-        "unist-util-visit": "^1.1.0"
-      },
-      "dependencies": {
-        "unist-util-is": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-          "dev": true
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-          "dev": true,
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-          "dev": true,
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
-        }
-      }
-    },
-    "unist-util-stringify-position": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.2"
-      }
     },
     "unist-util-visit": {
       "version": "2.0.2",
@@ -4809,35 +4509,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "vfile": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
-      "integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "is-buffer": "^2.0.0",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^2.0.0",
-        "vfile-message": "^2.0.0"
-      }
-    },
-    "vfile-location": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
-      "dev": true
-    },
-    "vfile-message": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "w3c-hr-time": {
@@ -4967,12 +4638,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/packages/curriculum-compiler-json/__tests__/fixtures/exercise/sample/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/exercise/sample/parsed.json
@@ -1,10 +1,7 @@
 {
   "metadata": {
     "author": "milesflo",
-    "levels": [
-      "beginner",
-      "basic"
-    ],
+    "levels": ["beginner", "basic"],
     "type": "exercise",
     "link": "https://www.codewars.com/kata/classy-classes",
     "linkType": "codewars",
@@ -21,7 +18,9 @@
       }
     ]
   },
-  "headline": "JS Practice `this`",
+  "headline": {
+    "rawText": "JS Practice `this`"
+  },
   "exercise": {
     "rawText": "Explore the `this` operator in JavaScript with Constructor functions\n",
     "question": "Explore the `this` operator in JavaScript with Constructor functions\n"

--- a/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
+++ b/packages/curriculum-compiler-json/__tests__/fixtures/insight/sample/parsed.json
@@ -18,8 +18,12 @@
       }
     ]
   },
-  "headline": "Sample title with `code` within",
-  "content": "This is a sample paragraph.[1]\n\nThis is a sample list[2]:\n\n* item one\n* item `two`\n\nSample code[3]:\n\n```javascript\nconsole.log('sample code')\n```\n",
+  "headline": {
+    "rawText": "Sample title with `code` within"
+  },
+  "content": {
+    "rawText": "This is a sample paragraph.[1]\n\nThis is a sample list[2]:\n\n* item one\n* item `two`\n\nSample code[3]:\n\n```javascript\nconsole.log('sample code')\n```\n"
+  },
   "practice": {
     "rawText": "This is a sample question with one gap:\n\n???\n\n* correct\n* incorrect\n* not a chance\n",
     "question": "This is a sample question with one gap:\n\n???\n",

--- a/packages/curriculum-compiler-json/compilers/headline.js
+++ b/packages/curriculum-compiler-json/compilers/headline.js
@@ -2,6 +2,10 @@ const { compileNodeToMarkdown } = require('./helpers');
 
 module.exports = function headline(node) {
   return {
-    headline: compileNodeToMarkdown(node).split('\n').join(''),
+    headline: {
+      rawText: compileNodeToMarkdown(node)
+        .split('\n')
+        .join(''),
+    },
   };
 };

--- a/packages/curriculum-compiler-json/compilers/headline.js
+++ b/packages/curriculum-compiler-json/compilers/headline.js
@@ -3,9 +3,7 @@ const { compileNodeToMarkdown } = require('./helpers');
 module.exports = function headline(node) {
   return {
     headline: {
-      rawText: compileNodeToMarkdown(node)
-        .split('\n')
-        .join(''),
+      rawText: compileNodeToMarkdown(node).split('\n').join(''),
     },
   };
 };

--- a/packages/curriculum-compiler-json/index.js
+++ b/packages/curriculum-compiler-json/index.js
@@ -12,7 +12,9 @@ const {
 
 const nodeSectionMap = {
   [sectionNames.CONTENT]: (node) => ({
-    content: compileNodeToMarkdown(node),
+    content: {
+      rawText: compileNodeToMarkdown(node),
+    },
   }),
   [sectionNames.GAME_CONTENT]: (node) => ({
     gameContent: compileNodeToInsightMarkdown(node),

--- a/packages/curriculum-compiler-json/package-lock.json
+++ b/packages/curriculum-compiler-json/package-lock.json
@@ -401,46 +401,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@enkidevs/curriculum-compiler-string": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-compiler-string/-/curriculum-compiler-string-6.0.0.tgz",
-			"integrity": "sha512-fXdtZfI+pUm6Lmr2Rkc14apY1Up/uF8Pll1V+P8Z5qUruVlApzpggLR1U1m2VROtRjPRRgfgBeq8BbxkSaCnUw==",
-			"requires": {
-				"@enkidevs/curriculum-helpers": "^7.0.0",
-				"@enkidevs/remark-stringify": "^5.1.1",
-				"js-yaml": "^3.13.0",
-				"unified": "^9.0.0"
-			}
-		},
-		"@enkidevs/curriculum-helpers": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-7.0.0.tgz",
-			"integrity": "sha512-bTxQaI+HThUMe2NtQdacHXFf5UWzQxJJYADi2mPT+oBK1F68Y5fgeysqb0VHvWggBvBv3HAjjLI+gjy22ttxTw==",
-			"requires": {
-				"unist-util-map": "^2.0.0"
-			}
-		},
-		"@enkidevs/remark-stringify": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@enkidevs/remark-stringify/-/remark-stringify-5.1.1.tgz",
-			"integrity": "sha512-J+YP1z4gKTR+HZFfKWA2TzjQ+RZcstw79Hyy42cHwJc0LxmGd/GZoGEgkK18hCKJMTdVG6+Yr1tLvz3QWAUQHg==",
-			"requires": {
-				"ccount": "^1.0.0",
-				"is-alphanumeric": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"longest-streak": "^2.0.1",
-				"markdown-escapes": "^1.0.0",
-				"markdown-table": "^1.1.0",
-				"mdast-util-compact": "^1.0.0",
-				"parse-entities": "^1.0.2",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"stringify-entities": "^1.0.1",
-				"unherit": "^1.0.4",
-				"xtend": "^4.0.1"
-			}
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -716,14 +676,6 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"@types/mdast": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-			"requires": {
-				"@types/unist": "*"
-			}
-		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -741,11 +693,6 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
-		},
-		"@types/unist": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"@types/yargs": {
 			"version": "15.0.4",
@@ -857,6 +804,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -1006,11 +954,6 @@
 				"babel-plugin-jest-hoist": "^25.4.0",
 				"babel-preset-current-node-syntax": "^0.1.2"
 			}
-		},
-		"bail": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1183,11 +1126,6 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
-		"ccount": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
-			"integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
-		},
 		"chalk": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -1197,26 +1135,6 @@
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
 			}
-		},
-		"character-entities": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
-		},
-		"character-entities-html4": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
-			"integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
-		},
-		"character-entities-legacy": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
-		},
-		"character-reference-invalid": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
 		},
 		"ci-info": {
 			"version": "2.0.0",
@@ -1567,7 +1485,8 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"estraverse": {
 			"version": "4.3.0",
@@ -1675,7 +1594,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -2079,7 +1999,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"ip-regex": {
 			"version": "2.1.0",
@@ -2105,25 +2026,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"is-alphabetical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
-		},
-		"is-alphanumeric": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
-			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
-		},
-		"is-alphanumerical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -2167,11 +2069,6 @@
 				}
 			}
 		},
-		"is-decimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
-		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -2209,21 +2106,11 @@
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
 		},
-		"is-hexadecimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
-		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
-		},
-		"is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -2245,11 +2132,6 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
-		},
-		"is-whitespace-character": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -2846,6 +2728,7 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -3016,11 +2899,6 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"longest-streak": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-			"integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
-		},
 		"make-dir": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -3052,24 +2930,6 @@
 			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
-			}
-		},
-		"markdown-escapes": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
-		},
-		"markdown-table": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
-			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
-		},
-		"mdast-util-compact": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.4.tgz",
-			"integrity": "sha512-3YDMQHI5vRiS2uygEFYaqckibpJtKq5Sj2c8JioeOQBU6INpKbdWzfyLqFFnDwEcEnRFIdMsguzs5pC1Jp4Isg==",
-			"requires": {
-				"unist-util-visit": "^1.1.0"
 			}
 		},
 		"merge-stream": {
@@ -3267,11 +3127,6 @@
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3388,19 +3243,6 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
-		},
-		"parse-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			}
 		},
 		"parse-json": {
 			"version": "5.0.0",
@@ -3624,12 +3466,8 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.2",
@@ -4219,7 +4057,8 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -4243,11 +4082,6 @@
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
-		},
-		"state-toggle": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -4306,17 +4140,6 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.0"
-			}
-		},
-		"stringify-entities": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
-			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
-			"requires": {
-				"character-entities-html4": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -4479,11 +4302,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"trough": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4529,35 +4347,6 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
-		"unherit": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-			"integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-			"requires": {
-				"inherits": "^2.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
-		"unified": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
-			"integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
-			"requires": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
-			}
-		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4582,44 +4371,6 @@
 			"requires": {
 				"x-is-array": "^0.1.0",
 				"x-is-object": "^0.1.0"
-			}
-		},
-		"unist-util-is": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-		},
-		"unist-util-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-2.0.1.tgz",
-			"integrity": "sha512-VdNvk4BQUUU9Rgr8iUOvclHa/iN9O+6Dt66FKij8l9OVezGG37gGWCPU5KSax1R2degqXFvl3kWTkvzL79e9tQ==",
-			"requires": {
-				"@types/mdast": "^3.0.0",
-				"object-assign": "^4.0.0"
-			}
-		},
-		"unist-util-stringify-position": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-			"integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-			"requires": {
-				"@types/unist": "^2.0.2"
-			}
-		},
-		"unist-util-visit": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-			"requires": {
-				"unist-util-visit-parents": "^2.0.0"
-			}
-		},
-		"unist-util-visit-parents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-			"requires": {
-				"unist-util-is": "^3.0.0"
 			}
 		},
 		"universalify": {
@@ -4733,34 +4484,6 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
-			}
-		},
-		"vfile": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
-			"integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
-			}
-		},
-		"vfile-message": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-			"integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
 			}
 		},
 		"w3c-hr-time": {
@@ -4901,11 +4624,6 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/packages/curriculum-compiler-string/package-lock.json
+++ b/packages/curriculum-compiler-string/package-lock.json
@@ -401,14 +401,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@enkidevs/curriculum-helpers": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-7.0.0.tgz",
-			"integrity": "sha512-bTxQaI+HThUMe2NtQdacHXFf5UWzQxJJYADi2mPT+oBK1F68Y5fgeysqb0VHvWggBvBv3HAjjLI+gjy22ttxTw==",
-			"requires": {
-				"unist-util-map": "^2.0.0"
-			}
-		},
 		"@enkidevs/remark-stringify": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/@enkidevs/remark-stringify/-/remark-stringify-5.1.1.tgz",
@@ -703,14 +695,6 @@
 			"requires": {
 				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"@types/mdast": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-			"requires": {
-				"@types/unist": "*"
 			}
 		},
 		"@types/normalize-package-data": {
@@ -3262,11 +3246,6 @@
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4569,15 +4548,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
 			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
-		},
-		"unist-util-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-2.0.1.tgz",
-			"integrity": "sha512-VdNvk4BQUUU9Rgr8iUOvclHa/iN9O+6Dt66FKij8l9OVezGG37gGWCPU5KSax1R2degqXFvl3kWTkvzL79e9tQ==",
-			"requires": {
-				"@types/mdast": "^3.0.0",
-				"object-assign": "^4.0.0"
-			}
 		},
 		"unist-util-modify-children": {
 			"version": "1.1.2",

--- a/packages/curriculum-parser-json/package-lock.json
+++ b/packages/curriculum-parser-json/package-lock.json
@@ -401,29 +401,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@enkidevs/curriculum-helpers": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-7.0.0.tgz",
-			"integrity": "sha512-bTxQaI+HThUMe2NtQdacHXFf5UWzQxJJYADi2mPT+oBK1F68Y5fgeysqb0VHvWggBvBv3HAjjLI+gjy22ttxTw==",
-			"requires": {
-				"unist-util-map": "^2.0.0"
-			}
-		},
-		"@enkidevs/curriculum-parser-markdown": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-parser-markdown/-/curriculum-parser-markdown-7.0.0.tgz",
-			"integrity": "sha512-pbsPCZTGTLbaw+/u+TcJqJUS8fhje/tPYxpYIdhxndu910+tOZTxe1RDwSOulrYeIi6tCPBsw9fWkQQRhs9RCw==",
-			"requires": {
-				"@enkidevs/curriculum-helpers": "^7.0.0",
-				"decode-uri-component": "^0.2.0",
-				"js-yaml": "^3.13.0",
-				"remark-frontmatter": "^1.3.1",
-				"remark-parse": "^7.0.1",
-				"unified": "^9.0.0",
-				"unist-builder": "^2.0.0",
-				"unist-util-visit": "^2.0.0"
-			}
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -699,14 +676,6 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"@types/mdast": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-			"requires": {
-				"@types/unist": "*"
-			}
-		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -724,11 +693,6 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
-		},
-		"@types/unist": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"@types/yargs": {
 			"version": "15.0.4",
@@ -990,11 +954,6 @@
 				"babel-preset-current-node-syntax": "^0.1.2"
 			}
 		},
-		"bail": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1176,21 +1135,6 @@
 				"supports-color": "^7.1.0"
 			}
 		},
-		"character-entities": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
-		},
-		"character-entities-legacy": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
-		},
-		"character-reference-invalid": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
-		},
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1236,11 +1180,6 @@
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
-		},
-		"collapse-white-space": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
 		},
 		"collect-v8-coverage": {
 			"version": "1.0.1",
@@ -1406,7 +1345,8 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -1652,7 +1592,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -1764,14 +1705,6 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
-		"fault": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-			"requires": {
-				"format": "^0.2.0"
-			}
-		},
 		"fb-watchman": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -1822,11 +1755,6 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -2069,7 +1997,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"ip-regex": {
 			"version": "2.1.0",
@@ -2095,20 +2024,6 @@
 						"is-buffer": "^1.1.5"
 					}
 				}
-			}
-		},
-		"is-alphabetical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
-		},
-		"is-alphanumerical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -2152,11 +2067,6 @@
 				}
 			}
 		},
-		"is-decimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
-		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -2194,21 +2104,11 @@
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
 		},
-		"is-hexadecimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
-		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
-		},
-		"is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -2231,21 +2131,11 @@
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
-		"is-whitespace-character": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
-		},
-		"is-word-character": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
 		},
 		"is-wsl": {
 			"version": "2.1.1",
@@ -3039,11 +2929,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"markdown-escapes": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
-		},
 		"merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3239,11 +3124,6 @@
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3360,19 +3240,6 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
-		},
-		"parse-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			}
 		},
 		"parse-json": {
 			"version": "5.0.0",
@@ -3581,37 +3448,6 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
-		"remark-frontmatter": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz",
-			"integrity": "sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==",
-			"requires": {
-				"fault": "^1.0.1",
-				"xtend": "^4.0.1"
-			}
-		},
-		"remark-parse": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.2.tgz",
-			"integrity": "sha512-9+my0lQS80IQkYXsMA8Sg6m9QfXYJBnXjWYN5U+kFc5/n69t+XZVXU/ZBYr3cYH8FheEGf1v87rkFDhJ8bVgMA==",
-			"requires": {
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^1.1.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^1.0.0",
-				"vfile-location": "^2.0.0",
-				"xtend": "^4.0.1"
-			}
-		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -3627,12 +3463,8 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
-		"replace-ext": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.2",
@@ -4247,11 +4079,6 @@
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
 			"dev": true
 		},
-		"state-toggle": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
-		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4471,21 +4298,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-		},
-		"trim-trailing-lines": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
-			"integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
-		},
-		"trough": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
-		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4531,35 +4343,6 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
-		"unherit": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-			"integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-			"requires": {
-				"inherits": "^2.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
-		"unified": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
-			"integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
-			"requires": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
-			}
-		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4576,80 +4359,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
 			"integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw=="
-		},
-		"unist-util-is": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
-		},
-		"unist-util-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-2.0.1.tgz",
-			"integrity": "sha512-VdNvk4BQUUU9Rgr8iUOvclHa/iN9O+6Dt66FKij8l9OVezGG37gGWCPU5KSax1R2degqXFvl3kWTkvzL79e9tQ==",
-			"requires": {
-				"@types/mdast": "^3.0.0",
-				"object-assign": "^4.0.0"
-			}
-		},
-		"unist-util-remove-position": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-			"integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-			"requires": {
-				"unist-util-visit": "^1.1.0"
-			},
-			"dependencies": {
-				"unist-util-visit": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-					"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-					"requires": {
-						"unist-util-visit-parents": "^2.0.0"
-					}
-				}
-			}
-		},
-		"unist-util-stringify-position": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-			"integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-			"requires": {
-				"@types/unist": "^2.0.2"
-			}
-		},
-		"unist-util-visit": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
-			"integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"unist-util-is": "^4.0.0",
-				"unist-util-visit-parents": "^3.0.0"
-			},
-			"dependencies": {
-				"unist-util-is": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
-					"integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
-				},
-				"unist-util-visit-parents": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
-					"integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-is": "^4.0.0"
-					}
-				}
-			}
-		},
-		"unist-util-visit-parents": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-			"requires": {
-				"unist-util-is": "^3.0.0"
-			}
 		},
 		"universalify": {
 			"version": "1.0.0",
@@ -4762,39 +4471,6 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
-			}
-		},
-		"vfile": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.0.tgz",
-			"integrity": "sha512-BaTPalregj++64xbGK6uIlsurN3BCRNM/P2Pg8HezlGzKd1O9PrwIac6bd9Pdx2uTb0QHoioZ+rXKolbVXEgJg==",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
-			}
-		},
-		"vfile-location": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
-		},
-		"vfile-message": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-			"integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
 			}
 		},
 		"w3c-hr-time": {
@@ -4925,11 +4601,6 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/packages/curriculum-parser-markdown/package-lock.json
+++ b/packages/curriculum-parser-markdown/package-lock.json
@@ -401,14 +401,6 @@
 				"minimist": "^1.2.0"
 			}
 		},
-		"@enkidevs/curriculum-helpers": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@enkidevs/curriculum-helpers/-/curriculum-helpers-7.0.1.tgz",
-			"integrity": "sha512-8hA3uKlrwjftBlRE00uA33xKlL6jbpKiFAvNx5lPZ4G+iV7zQ1W8JLUtbDrhLz0JzhnMXG//Bt4N3gEnmwtetQ==",
-			"requires": {
-				"unist-util-map": "^2.0.0"
-			}
-		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -682,14 +674,6 @@
 			"requires": {
 				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"@types/mdast": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
-			"integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-			"requires": {
-				"@types/unist": "*"
 			}
 		},
 		"@types/normalize-package-data": {
@@ -3229,11 +3213,6 @@
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4571,15 +4550,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.1.tgz",
 			"integrity": "sha512-7NYjErP4LJtkEptPR22wO5RsCPnHZZrop7t2SoQzjvpFedCFer4WW8ujj9GI5DkUX7yVcffXLjoURf6h2QUv6Q=="
-		},
-		"unist-util-map": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-map/-/unist-util-map-2.0.1.tgz",
-			"integrity": "sha512-VdNvk4BQUUU9Rgr8iUOvclHa/iN9O+6Dt66FKij8l9OVezGG37gGWCPU5KSax1R2degqXFvl3kWTkvzL79e9tQ==",
-			"requires": {
-				"@types/mdast": "^3.0.0",
-				"object-assign": "^4.0.0"
-			}
 		},
 		"unist-util-remove-position": {
 			"version": "2.0.1",


### PR DESCRIPTION
Make the API more robust by using the same `rawText` convention for headline & content;

Should also change `extract-upload-zip.ts#L148-L149` in spider