### PR TITLE
make sure headline stringification of markdown elements combine…

### DIFF
--- a/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/ast.json
+++ b/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/ast.json
@@ -25,8 +25,30 @@
       "type": "headline",
       "children": [
         {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "Balanced"
+            }
+          ]
+        },
+        {
           "type": "text",
-          "value": "Balanced vs. Unbalanced Binary Trees"
+          "value": " vs. "
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "Unbalanced"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": " Binary Trees"
         }
       ]
     },

--- a/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/stringified.md
+++ b/packages/curriculum-compiler-string/__tests__/fixtures/insight/sample/stringified.md
@@ -14,7 +14,7 @@ links:
 parent: removing-keys-from-a-binary-search-tree
 ---
 
-# Balanced vs. Unbalanced Binary Trees
+# **Balanced** vs. **Unbalanced** Binary Trees
 
 
 ---

--- a/packages/curriculum-compiler-string/plugins/insight/headline.js
+++ b/packages/curriculum-compiler-string/plugins/insight/headline.js
@@ -8,10 +8,14 @@ module.exports = function headline() {
     const { visitors } = Compiler.prototype;
     if (visitors) {
       visitors.headline = function visitHeadline(h) {
-        const content = unified().use(markdown).stringify({
-          type: 'root',
-          children: h.children,
-        });
+        const content = unified()
+          .use(markdown)
+          .stringify({
+            type: 'root',
+            children: h.children,
+          })
+          .replace(/\n{2,}/g, ' ')
+          .replace(/ {2,}/g, ' ');
         return `# ${content}`;
       };
     }


### PR DESCRIPTION
:bug: make sure headline stringification of markdown elements combines into a single line

### Before


Headline string

```md
# General **GitHub** workflow
```

when parsed and compiled back to a string would generate

```md
# General 

**GitHub**

 workflow
```

### After

Parsing and compiling a headline to a string re-creates the original input

```md
# General **GitHub** workflow
```